### PR TITLE
Say hello

### DIFF
--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -331,8 +331,14 @@
             }
         }
 
+        System.debug('🔧 VALIDATION COUNT DEBUG: Total updated records: ' + updatedFieldsPerRecord.size() + ', Clean records (no errors): ' + cleanUpdatedMap.size());
+        System.debug('🔧 Records with errors: ' + result.fieldErrors.keySet());
+        System.debug('🔧 Clean updated records: ' + cleanUpdatedMap.keySet());
+
         if (!cleanUpdatedMap.isEmpty()) {
             Set<String> objectNames = new Set<String>(objectTypePerRecord.values());
+            System.debug('🔧 Processing objects: ' + objectNames);
+            
             for (String obj : objectNames) {
                 List<Object_Tracker__c> trackers = [
                     SELECT Id FROM Object_Tracker__c
@@ -340,11 +346,18 @@
                     ORDER BY CreatedDate DESC LIMIT 1
                 ];
                 if (!trackers.isEmpty()) {
+                    System.debug('🔧 Found tracker for object ' + obj + ': ' + trackers[0].Id);
+                    System.debug('🔧 Calling removeUpdatedFieldsFromPayloadBatch...');
                     removeUpdatedFieldsFromPayloadBatch(trackers[0].Id, cleanUpdatedMap);
-                    // Update user validation counts after successful updates
+                    System.debug('🔧 Calling updateUserValidationCounts...');
                     updateUserValidationCounts(trackers[0].Id, cleanUpdatedMap);
+                    System.debug('🔧 Completed validation count update for tracker: ' + trackers[0].Id);
+                } else {
+                    System.debug('🔧 No tracker found for object: ' + obj);
                 }
             }
+        } else {
+            System.debug('🔧 No clean updated records to process - all records had errors');
         }
 
         result.hasErrors = !result.fieldErrors.isEmpty();

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -470,12 +470,22 @@
             for (Owner_based_Line_Items__c item : items) {
                 Id ownerId = item.OwnerRecordId__c;
                 Integer resolvedCount = 0;
+                List<String> updatedRecordsForOwner = new List<String>();
+                List<String> resolvedRecordsForOwner = new List<String>();
+                List<String> stillMissingRecordsForOwner = new List<String>();
+
+                System.debug('=== DEBUGGING OWNER ' + ownerId + ' ===');
+                System.debug('Payload length: ' + (item.Payload__c != null ? item.Payload__c.length() : 0));
+                System.debug('Payload preview (first 500 chars): ' + (item.Payload__c != null && item.Payload__c.length() > 500 ? item.Payload__c.substring(0, 500) + '...' : item.Payload__c));
 
                 // Check each record that was updated for this owner
                 for (Id recordId : updatedFieldsByRecordId.keySet()) {
                     if (recordToOwnerMap.get(recordId) == ownerId) {
-                        // Check if this record is no longer in the payload (completely resolved)
                         String recordIdStr = String.valueOf(recordId);
+                        updatedRecordsForOwner.add(recordIdStr);
+                        List<String> updatedFields = updatedFieldsByRecordId.get(recordId);
+                        
+                        // Check if this record is no longer in the payload (completely resolved)
                         Boolean recordStillInPayload = false;
                         
                         if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
@@ -486,16 +496,35 @@
                         if (!recordStillInPayload) {
                             // Record was completely resolved (all missing fields fixed)
                             resolvedCount++;
-                            System.debug('Record ' + recordIdStr + ' was completely resolved for owner ' + ownerId);
+                            resolvedRecordsForOwner.add(recordIdStr);
+                            System.debug('✅ Record ' + recordIdStr + ' was COMPLETELY RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
                         } else {
-                            System.debug('Record ' + recordIdStr + ' still has missing fields for owner ' + ownerId);
+                            stillMissingRecordsForOwner.add(recordIdStr);
+                            System.debug('⚠️  Record ' + recordIdStr + ' STILL HAS MISSING FIELDS for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            
+                            // Try to extract what fields are still missing for this record
+                            if (item.Payload__c.contains('"' + recordIdStr + '":')) {
+                                Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
+                                Integer arrayStart = item.Payload__c.indexOf('[', startPos);
+                                Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
+                                if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
+                                    String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
+                                    System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
+                                }
+                            }
                         }
                     }
                 }
 
+                System.debug('SUMMARY FOR OWNER ' + ownerId + ':');
+                System.debug('- Total updated records: ' + updatedRecordsForOwner.size() + ' → ' + updatedRecordsForOwner);
+                System.debug('- Completely resolved: ' + resolvedRecordsForOwner.size() + ' → ' + resolvedRecordsForOwner);
+                System.debug('- Still have missing fields: ' + stillMissingRecordsForOwner.size() + ' → ' + stillMissingRecordsForOwner);
+                System.debug('=== END DEBUGGING OWNER ' + ownerId + ' ===');
+
                 if (resolvedCount > 0) {
                     userToResolvedRecordsCount.put(ownerId, resolvedCount);
-                    System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved');
+                    System.debug('🎯 Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved - COUNT WILL DECREASE BY ' + resolvedCount);
                 }
             }
 

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -530,11 +530,16 @@
                         
                         // Check if this record is still in ANY of the owner's payloads
                         Boolean recordStillInAnyPayload = false;
+                        String foundInPayloadId = '';
+                        
+                        System.debug('🔍 Checking if record ' + recordIdStr + ' exists in any payload...');
                         
                         for (Owner_based_Line_Items__c item : ownerPayloads) {
                             if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
                                 if (item.Payload__c.contains('"' + recordIdStr + '":')) {
                                     recordStillInAnyPayload = true;
+                                    foundInPayloadId = item.Id;
+                                    System.debug('❌ Record ' + recordIdStr + ' STILL EXISTS in payload ' + item.Id + ' (length: ' + item.Payload__c.length() + ')');
                                     break; // Found in one payload, no need to check others
                                 }
                             }
@@ -544,8 +549,10 @@
                             // Record was completely removed from ALL payloads (all missing fields resolved)
                             resolvedCount++;
                             resolvedRecordsForOwner.add(recordIdStr);
+                            System.debug('✅ Record ' + recordIdStr + ' COMPLETELY RESOLVED - not found in any payload');
                         } else {
                             stillMissingRecordsForOwner.add(recordIdStr);
+                            System.debug('⚠️ Record ' + recordIdStr + ' STILL HAS MISSING FIELDS - found in payload ' + foundInPayloadId);
                         }
                     }
                 }

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -354,6 +354,8 @@
     /**
      * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
      * after successful record updates. Decreases the missing count for users who had records updated.
+     * This method counts records that were completely resolved (no more missing fields) by 
+     * checking the payload updates to see which records were fully removed.
      * @param trackerId The Object_Tracker__c record ID
      * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
      */
@@ -391,23 +393,12 @@
             Set<Id> recordIds = updatedFieldsByRecordId.keySet();
             Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
 
-            // Count how many fields were updated per user
-            Map<Id, Integer> userToUpdatedFieldsCount = new Map<Id, Integer>();
-            for (Id recordId : updatedFieldsByRecordId.keySet()) {
-                Id ownerId = recordToOwnerMap.get(recordId);
-                if (ownerId != null) {
-                    Integer fieldCount = updatedFieldsByRecordId.get(recordId).size();
-                    if (userToUpdatedFieldsCount.containsKey(ownerId)) {
-                        userToUpdatedFieldsCount.put(ownerId, userToUpdatedFieldsCount.get(ownerId) + fieldCount);
-                    } else {
-                        userToUpdatedFieldsCount.put(ownerId, fieldCount);
-                    }
-                }
-            }
+            // Count records that were completely resolved (removed from payload) per user
+            Map<Id, Integer> userToResolvedRecordsCount = getResolvedRecordsCount(trackerId, updatedFieldsByRecordId, recordToOwnerMap);
 
             // Update the user validation counts
             Boolean hasChanges = false;
-            for (Id userId : userToUpdatedFieldsCount.keySet()) {
+            for (Id userId : userToResolvedRecordsCount.keySet()) {
                 String userIdStr = String.valueOf(userId);
                 if (userValidationMap.containsKey(userIdStr)) {
                     String currentValue = String.valueOf(userValidationMap.get(userIdStr));
@@ -417,16 +408,16 @@
                             try {
                                 Integer currentMissing = Integer.valueOf(parts[0]);
                                 Integer totalRecords = Integer.valueOf(parts[1]);
-                                Integer updatedFields = userToUpdatedFieldsCount.get(userId);
+                                Integer resolvedRecords = userToResolvedRecordsCount.get(userId);
                                 
-                                // Decrease missing count by the number of fields updated
-                                Integer newMissing = Math.max(0, currentMissing - updatedFields);
+                                // Decrease missing count by the number of records that were completely resolved
+                                Integer newMissing = Math.max(0, currentMissing - resolvedRecords);
                                 
                                 String newValue = newMissing + '/' + totalRecords;
                                 userValidationMap.put(userIdStr, newValue);
                                 hasChanges = true;
                                 
-                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue);
+                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue + ' (Resolved ' + resolvedRecords + ' records completely)');
                             } catch (Exception e) {
                                 System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
                             }
@@ -446,6 +437,68 @@
             System.debug('Error in updateUserValidationCounts: ' + e.getMessage());
             // Don't throw exception to avoid breaking the main flow
         }
+    }
+
+    /**
+     * @description Count how many records were completely resolved (removed from payload) per user
+     * by analyzing the Owner_based_Line_Items__c payload changes
+     * @param trackerId The Object_Tracker__c record ID
+     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
+     * @param recordToOwnerMap Map of record ID to owner ID
+     * @return Map of user ID to count of completely resolved records
+     */
+    private static Map<Id, Integer> getResolvedRecordsCount(
+        Id trackerId, 
+        Map<Id, List<String>> updatedFieldsByRecordId, 
+        Map<Id, Id> recordToOwnerMap
+    ) {
+        Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
+        
+        try {
+            // Get owner IDs for the updated records
+            Set<Id> ownerIds = new Set<Id>(recordToOwnerMap.values());
+            
+            // Query Owner_based_Line_Items__c to check which records were completely removed
+            List<Owner_based_Line_Items__c> items = [
+                SELECT Id, OwnerRecordId__c, Payload__c
+                FROM Owner_based_Line_Items__c
+                WHERE OwnerRecordId__c IN :ownerIds
+                AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
+                WITH SECURITY_ENFORCED
+            ];
+
+            // Check each owner's payload to see which records are no longer present
+            for (Owner_based_Line_Items__c item : items) {
+                if (String.isBlank(item.Payload__c)) {
+                    continue;
+                }
+
+                Id ownerId = item.OwnerRecordId__c;
+                Integer resolvedCount = 0;
+
+                // Check which of the updated records belonging to this owner are no longer in the payload
+                for (Id recordId : updatedFieldsByRecordId.keySet()) {
+                    if (recordToOwnerMap.get(recordId) == ownerId) {
+                        // Check if this record is still in the payload
+                        String recordIdStr = String.valueOf(recordId);
+                        if (!item.Payload__c.contains('"' + recordIdStr + '"')) {
+                            // Record was completely removed from payload (all missing fields resolved)
+                            resolvedCount++;
+                        }
+                    }
+                }
+
+                if (resolvedCount > 0) {
+                    userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                    System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved');
+                }
+            }
+
+        } catch (Exception e) {
+            System.debug('Error in getResolvedRecordsCount: ' + e.getMessage());
+        }
+
+        return userToResolvedRecordsCount;
     }
 
     /**

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -466,17 +466,25 @@
                 WITH SECURITY_ENFORCED
             ];
 
-            // For each owner, check which updated records are no longer in their payload
+            // Group all payloads by owner to avoid double counting
+            Map<Id, List<Owner_based_Line_Items__c>> ownerToPayloads = new Map<Id, List<Owner_based_Line_Items__c>>();
             for (Owner_based_Line_Items__c item : items) {
                 Id ownerId = item.OwnerRecordId__c;
+                if (!ownerToPayloads.containsKey(ownerId)) {
+                    ownerToPayloads.put(ownerId, new List<Owner_based_Line_Items__c>());
+                }
+                ownerToPayloads.get(ownerId).add(item);
+            }
+
+            // Process each owner only once, checking all their payloads
+            for (Id ownerId : ownerToPayloads.keySet()) {
+                List<Owner_based_Line_Items__c> ownerPayloads = ownerToPayloads.get(ownerId);
                 Integer resolvedCount = 0;
                 List<String> updatedRecordsForOwner = new List<String>();
                 List<String> resolvedRecordsForOwner = new List<String>();
                 List<String> stillMissingRecordsForOwner = new List<String>();
 
-                System.debug('=== DEBUGGING OWNER ' + ownerId + ' ===');
-                System.debug('Payload length: ' + (item.Payload__c != null ? item.Payload__c.length() : 0));
-                System.debug('Payload preview (first 500 chars): ' + (item.Payload__c != null && item.Payload__c.length() > 500 ? item.Payload__c.substring(0, 500) + '...' : item.Payload__c));
+                System.debug('=== DEBUGGING OWNER ' + ownerId + ' (' + ownerPayloads.size() + ' payload items) ===');
 
                 // Check each record that was updated for this owner
                 for (Id recordId : updatedFieldsByRecordId.keySet()) {
@@ -485,33 +493,36 @@
                         updatedRecordsForOwner.add(recordIdStr);
                         List<String> updatedFields = updatedFieldsByRecordId.get(recordId);
                         
-                        // Check if this record is no longer in the payload (completely resolved)
-                        Boolean recordStillInPayload = false;
+                        // Check if this record is still in ANY of the owner's payloads
+                        Boolean recordStillInAnyPayload = false;
                         
-                        if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
-                            // More precise check - look for the exact record key pattern
-                            recordStillInPayload = item.Payload__c.contains('"' + recordIdStr + '":');
+                        for (Owner_based_Line_Items__c item : ownerPayloads) {
+                            if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
+                                if (item.Payload__c.contains('"' + recordIdStr + '":')) {
+                                    recordStillInAnyPayload = true;
+                                    System.debug('   Record ' + recordIdStr + ' found in payload item ' + item.Id + ' (length: ' + item.Payload__c.length() + ')');
+                                    
+                                    // Extract what fields are still missing
+                                    Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
+                                    Integer arrayStart = item.Payload__c.indexOf('[', startPos);
+                                    Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
+                                    if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
+                                        String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
+                                        System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
+                                    }
+                                    break; // Found in one payload, no need to check others
+                                }
+                            }
                         }
                         
-                        if (!recordStillInPayload) {
-                            // Record was completely resolved (all missing fields fixed)
+                        if (!recordStillInAnyPayload) {
+                            // Record was completely resolved (not found in any payload)
                             resolvedCount++;
                             resolvedRecordsForOwner.add(recordIdStr);
                             System.debug('✅ Record ' + recordIdStr + ' was COMPLETELY RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
                         } else {
                             stillMissingRecordsForOwner.add(recordIdStr);
                             System.debug('⚠️  Record ' + recordIdStr + ' STILL HAS MISSING FIELDS for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
-                            
-                            // Try to extract what fields are still missing for this record
-                            if (item.Payload__c.contains('"' + recordIdStr + '":')) {
-                                Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
-                                Integer arrayStart = item.Payload__c.indexOf('[', startPos);
-                                Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
-                                if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
-                                    String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
-                                    System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
-                                }
-                            }
                         }
                     }
                 }

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -353,9 +353,8 @@
 
     /**
      * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
-     * after successful record updates. Decreases the missing count for users who had records updated.
-     * This method counts records that were completely resolved (no more missing fields) by 
-     * checking the payload updates to see which records were fully removed.
+     * after successful record updates. This method uses the removeUpdatedFieldsFromPayloadBatch
+     * tracking to determine exactly how many records were completely resolved.
      * @param trackerId The Object_Tracker__c record ID
      * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
      */
@@ -393,8 +392,8 @@
             Set<Id> recordIds = updatedFieldsByRecordId.keySet();
             Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
 
-            // Count records that were completely resolved (removed from payload) per user
-            Map<Id, Integer> userToResolvedRecordsCount = getResolvedRecordsCount(trackerId, updatedFieldsByRecordId, recordToOwnerMap);
+            // Use the global tracking variable to get accurate resolved record counts
+            Map<Id, Integer> userToResolvedRecordsCount = getActualResolvedRecordsCount(recordToOwnerMap);
 
             // Update the user validation counts
             Boolean hasChanges = false;
@@ -433,69 +432,33 @@
                 System.debug('Updated Object_Tracker__c User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
             }
 
+            // Clear the tracking variable after use
+            resolvedRecordsTracker.clear();
+
         } catch (Exception e) {
             System.debug('Error in updateUserValidationCounts: ' + e.getMessage());
             // Don't throw exception to avoid breaking the main flow
         }
     }
 
+    // Static variable to track resolved records during payload processing
+    private static Map<Id, Integer> resolvedRecordsTracker = new Map<Id, Integer>();
+
     /**
-     * @description Count how many records were completely resolved (removed from payload) per user
-     * by analyzing the Owner_based_Line_Items__c payload changes
-     * @param trackerId The Object_Tracker__c record ID
-     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
+     * @description Get the actual resolved records count from the tracking variable
      * @param recordToOwnerMap Map of record ID to owner ID
      * @return Map of user ID to count of completely resolved records
      */
-    private static Map<Id, Integer> getResolvedRecordsCount(
-        Id trackerId, 
-        Map<Id, List<String>> updatedFieldsByRecordId, 
-        Map<Id, Id> recordToOwnerMap
-    ) {
+    private static Map<Id, Integer> getActualResolvedRecordsCount(Map<Id, Id> recordToOwnerMap) {
         Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
         
-        try {
-            // Get owner IDs for the updated records
-            Set<Id> ownerIds = new Set<Id>(recordToOwnerMap.values());
-            
-            // Query Owner_based_Line_Items__c to check which records were completely removed
-            List<Owner_based_Line_Items__c> items = [
-                SELECT Id, OwnerRecordId__c, Payload__c
-                FROM Owner_based_Line_Items__c
-                WHERE OwnerRecordId__c IN :ownerIds
-                AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
-                WITH SECURITY_ENFORCED
-            ];
-
-            // Check each owner's payload to see which records are no longer present
-            for (Owner_based_Line_Items__c item : items) {
-                if (String.isBlank(item.Payload__c)) {
-                    continue;
-                }
-
-                Id ownerId = item.OwnerRecordId__c;
-                Integer resolvedCount = 0;
-
-                // Check which of the updated records belonging to this owner are no longer in the payload
-                for (Id recordId : updatedFieldsByRecordId.keySet()) {
-                    if (recordToOwnerMap.get(recordId) == ownerId) {
-                        // Check if this record is still in the payload
-                        String recordIdStr = String.valueOf(recordId);
-                        if (!item.Payload__c.contains('"' + recordIdStr + '"')) {
-                            // Record was completely removed from payload (all missing fields resolved)
-                            resolvedCount++;
-                        }
-                    }
-                }
-
-                if (resolvedCount > 0) {
-                    userToResolvedRecordsCount.put(ownerId, resolvedCount);
-                    System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved');
-                }
+        // Use the tracked data from removeUpdatedFieldsFromPayloadBatch
+        for (Id ownerId : resolvedRecordsTracker.keySet()) {
+            Integer resolvedCount = resolvedRecordsTracker.get(ownerId);
+            if (resolvedCount > 0) {
+                userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records actually resolved (from tracker)');
             }
-
-        } catch (Exception e) {
-            System.debug('Error in getResolvedRecordsCount: ' + e.getMessage());
         }
 
         return userToResolvedRecordsCount;
@@ -667,6 +630,17 @@
                             item.Payload__c = payload.isEmpty() ? null : JSON.serialize(payload);
                             payloadStr = item.Payload__c == null ? '{}' : item.Payload__c;
                             toUpdate.add(item);
+                            
+                            // Track the actual number of records resolved for this owner
+                            if (removedRecords > 0) {
+                                if (resolvedRecordsTracker.containsKey(item.OwnerRecordId__c)) {
+                                    resolvedRecordsTracker.put(item.OwnerRecordId__c, 
+                                        resolvedRecordsTracker.get(item.OwnerRecordId__c) + removedRecords);
+                                } else {
+                                    resolvedRecordsTracker.put(item.OwnerRecordId__c, removedRecords);
+                                }
+                            }
+                            
                             System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (map) before=' + beforeCount + ' after=' + afterCount + ' removed=' + removedRecords);
                             // Avoid processing the same item again via string path which can cause duplicate DML IDs
                             continue;
@@ -784,6 +758,17 @@
                         idxScan2 = pos2 + marker2.length();
                     }
                 }
+                
+                // Track the actual number of records resolved for this owner (string path)
+                if (removedRecordsStr > 0) {
+                    if (resolvedRecordsTracker.containsKey(item.OwnerRecordId__c)) {
+                        resolvedRecordsTracker.put(item.OwnerRecordId__c, 
+                            resolvedRecordsTracker.get(item.OwnerRecordId__c) + removedRecordsStr);
+                    } else {
+                        resolvedRecordsTracker.put(item.OwnerRecordId__c, removedRecordsStr);
+                    }
+                }
+                
                 System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (string) before=' + beforeCountStr + ' after=' + afterCountStr + ' removed=' + removedRecordsStr);
             }
             } catch (Exception e) {

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -338,22 +338,37 @@
         if (!cleanUpdatedMap.isEmpty()) {
             Set<String> objectNames = new Set<String>(objectTypePerRecord.values());
             System.debug('🔧 Processing objects: ' + objectNames);
+            System.debug('🔧 Clean updated map contains: ' + cleanUpdatedMap.keySet());
             
             for (String obj : objectNames) {
-                List<Object_Tracker__c> trackers = [
-                    SELECT Id FROM Object_Tracker__c
-                    WHERE Name = :obj
-                    ORDER BY CreatedDate DESC LIMIT 1
-                ];
-                if (!trackers.isEmpty()) {
-                    System.debug('🔧 Found tracker for object ' + obj + ': ' + trackers[0].Id);
-                    System.debug('🔧 Calling removeUpdatedFieldsFromPayloadBatch...');
-                    removeUpdatedFieldsFromPayloadBatch(trackers[0].Id, cleanUpdatedMap);
-                    System.debug('🔧 Calling updateUserValidationCounts...');
-                    updateUserValidationCounts(trackers[0].Id, cleanUpdatedMap);
-                    System.debug('🔧 Completed validation count update for tracker: ' + trackers[0].Id);
+                // Filter cleanUpdatedMap to only include records of this object type
+                Map<Id, List<String>> objectSpecificUpdates = new Map<Id, List<String>>();
+                for (Id recordId : cleanUpdatedMap.keySet()) {
+                    String recordObjectType = recordId.getSObjectType().getDescribe().getName();
+                    if (recordObjectType == obj) {
+                        objectSpecificUpdates.put(recordId, cleanUpdatedMap.get(recordId));
+                    }
+                }
+                
+                if (!objectSpecificUpdates.isEmpty()) {
+                    List<Object_Tracker__c> trackers = [
+                        SELECT Id FROM Object_Tracker__c
+                        WHERE Name = :obj
+                        ORDER BY CreatedDate DESC LIMIT 1
+                    ];
+                    if (!trackers.isEmpty()) {
+                        System.debug('🔧 Found tracker for object ' + obj + ': ' + trackers[0].Id);
+                        System.debug('🔧 Processing ' + objectSpecificUpdates.size() + ' records for this object: ' + objectSpecificUpdates.keySet());
+                        System.debug('🔧 Calling removeUpdatedFieldsFromPayloadBatch...');
+                        removeUpdatedFieldsFromPayloadBatch(trackers[0].Id, objectSpecificUpdates);
+                        System.debug('🔧 Calling updateUserValidationCounts...');
+                        updateUserValidationCounts(trackers[0].Id, objectSpecificUpdates);
+                        System.debug('🔧 Completed validation count update for tracker: ' + trackers[0].Id);
+                    } else {
+                        System.debug('🔧 No tracker found for object: ' + obj);
+                    }
                 } else {
-                    System.debug('🔧 No tracker found for object: ' + obj);
+                    System.debug('🔧 No records of type ' + obj + ' in clean updated map');
                 }
             }
         } else {

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -488,9 +488,15 @@
     ) {
         Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
         
+        System.debug('🚀 getRecordsResolvedAfterUpdate STARTED');
+        System.debug('🚀 trackerId: ' + trackerId);
+        System.debug('🚀 updatedFieldsByRecordId: ' + updatedFieldsByRecordId.keySet());
+        System.debug('🚀 recordToOwnerMap: ' + recordToOwnerMap);
+        
         try {
             // Get owner IDs for the updated records
             Set<Id> ownerIds = new Set<Id>(recordToOwnerMap.values());
+            System.debug('🚀 ownerIds to query: ' + ownerIds);
             
             // Query Owner_based_Line_Items__c to check current payload state
             List<Owner_based_Line_Items__c> items = [

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -493,55 +493,51 @@
                         updatedRecordsForOwner.add(recordIdStr);
                         List<String> updatedFields = updatedFieldsByRecordId.get(recordId);
                         
-                        // Check if ANY of the updated fields are still missing in the payloads
-                        Boolean anyUpdatedFieldStillMissing = false;
-                        List<String> stillMissingUpdatedFields = new List<String>();
+                        // Check if this record is still in ANY of the owner's payloads
+                        Boolean recordStillInAnyPayload = false;
+                        String foundInPayloadId = '';
+                        Integer payloadLength = 0;
+                        
+                        System.debug('🔍 Checking record ' + recordIdStr + ' across ' + ownerPayloads.size() + ' payload items...');
                         
                         for (Owner_based_Line_Items__c item : ownerPayloads) {
+                            System.debug('   Checking payload item ' + item.Id + ' (length: ' + (item.Payload__c != null ? item.Payload__c.length() : 0) + ')');
+                            
                             if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
                                 if (item.Payload__c.contains('"' + recordIdStr + '":')) {
-                                    // Extract the missing fields for this record
+                                    recordStillInAnyPayload = true;
+                                    foundInPayloadId = item.Id;
+                                    payloadLength = item.Payload__c.length();
+                                    
+                                    System.debug('   ✋ FOUND: Record ' + recordIdStr + ' exists in payload item ' + item.Id + ' (length: ' + payloadLength + ')');
+                                    
+                                    // Extract what fields are still missing
                                     Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
                                     Integer arrayStart = item.Payload__c.indexOf('[', startPos);
                                     Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
                                     if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
                                         String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
-                                        String[] missingFieldsArray = fieldsArray.replace('"', '').split(',');
-                                        
-                                        // Convert to lowercase for comparison
-                                        Set<String> missingFieldsSet = new Set<String>();
-                                        for (String field : missingFieldsArray) {
-                                            if (String.isNotBlank(field.trim())) {
-                                                missingFieldsSet.add(field.trim().toLowerCase());
-                                            }
-                                        }
-                                        
-                                        // Check if any of the updated fields are still in the missing fields
-                                        for (String updatedField : updatedFields) {
-                                            String updatedFieldLower = updatedField.toLowerCase();
-                                            if (missingFieldsSet.contains(updatedFieldLower)) {
-                                                anyUpdatedFieldStillMissing = true;
-                                                stillMissingUpdatedFields.add(updatedField);
-                                            }
-                                        }
-                                        
-                                        System.debug('   Record ' + recordIdStr + ' found in payload item ' + item.Id);
-                                        System.debug('   All missing fields in payload: ' + fieldsArray);
-                                        System.debug('   Updated fields that are still missing: ' + stillMissingUpdatedFields);
+                                        System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
                                     }
-                                    break; // Found the record, no need to check other payloads
+                                    break; // Found in one payload, no need to check others
+                                } else {
+                                    System.debug('   ✅ NOT FOUND: Record ' + recordIdStr + ' not in payload item ' + item.Id);
                                 }
+                            } else {
+                                System.debug('   ⭕ EMPTY: Payload item ' + item.Id + ' is empty or null');
                             }
                         }
                         
-                        if (!anyUpdatedFieldStillMissing) {
-                            // All updated fields have been resolved (none of the updated fields are still missing)
+                        if (!recordStillInAnyPayload) {
+                            // Record was completely removed from ALL payloads (all missing fields resolved)
                             resolvedCount++;
                             resolvedRecordsForOwner.add(recordIdStr);
-                            System.debug('✅ Record ' + recordIdStr + ' - ALL UPDATED FIELDS RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            System.debug('✅ Record ' + recordIdStr + ' was COMPLETELY RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            System.debug('   📊 RESOLUTION CONFIRMED: Record not found in any of the ' + ownerPayloads.size() + ' payload items');
                         } else {
                             stillMissingRecordsForOwner.add(recordIdStr);
-                            System.debug('⚠️  Record ' + recordIdStr + ' - SOME UPDATED FIELDS STILL MISSING for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ', Still missing: ' + stillMissingUpdatedFields + ')');
+                            System.debug('⚠️  Record ' + recordIdStr + ' STILL HAS MISSING FIELDS for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            System.debug('   📍 STILL EXISTS: Found in payload item ' + foundInPayloadId + ' (length: ' + payloadLength + ')');
                         }
                     }
                 }

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -416,7 +416,7 @@
                                 userValidationMap.put(userIdStr, newValue);
                                 hasChanges = true;
                                 
-                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue + ' (Resolved ' + resolvedRecords + ' records completely)');
+
                             } catch (Exception e) {
                                 System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
                             }
@@ -429,7 +429,6 @@
             if (hasChanges) {
                 tracker.User_Record_Summary__c = JSON.serialize(userValidationMap);
                 update tracker;
-                System.debug('Updated Object_Tracker__c User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
             }
 
         } catch (Exception e) {
@@ -484,7 +483,7 @@
                 List<String> resolvedRecordsForOwner = new List<String>();
                 List<String> stillMissingRecordsForOwner = new List<String>();
 
-                System.debug('=== DEBUGGING OWNER ' + ownerId + ' (' + ownerPayloads.size() + ' payload items) ===');
+
 
                 // Check each record that was updated for this owner
                 for (Id recordId : updatedFieldsByRecordId.keySet()) {
@@ -495,36 +494,13 @@
                         
                         // Check if this record is still in ANY of the owner's payloads
                         Boolean recordStillInAnyPayload = false;
-                        String foundInPayloadId = '';
-                        Integer payloadLength = 0;
-                        
-                        System.debug('🔍 Checking record ' + recordIdStr + ' across ' + ownerPayloads.size() + ' payload items...');
                         
                         for (Owner_based_Line_Items__c item : ownerPayloads) {
-                            System.debug('   Checking payload item ' + item.Id + ' (length: ' + (item.Payload__c != null ? item.Payload__c.length() : 0) + ')');
-                            
                             if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
                                 if (item.Payload__c.contains('"' + recordIdStr + '":')) {
                                     recordStillInAnyPayload = true;
-                                    foundInPayloadId = item.Id;
-                                    payloadLength = item.Payload__c.length();
-                                    
-                                    System.debug('   ✋ FOUND: Record ' + recordIdStr + ' exists in payload item ' + item.Id + ' (length: ' + payloadLength + ')');
-                                    
-                                    // Extract what fields are still missing
-                                    Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
-                                    Integer arrayStart = item.Payload__c.indexOf('[', startPos);
-                                    Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
-                                    if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
-                                        String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
-                                        System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
-                                    }
                                     break; // Found in one payload, no need to check others
-                                } else {
-                                    System.debug('   ✅ NOT FOUND: Record ' + recordIdStr + ' not in payload item ' + item.Id);
                                 }
-                            } else {
-                                System.debug('   ⭕ EMPTY: Payload item ' + item.Id + ' is empty or null');
                             }
                         }
                         
@@ -532,25 +508,16 @@
                             // Record was completely removed from ALL payloads (all missing fields resolved)
                             resolvedCount++;
                             resolvedRecordsForOwner.add(recordIdStr);
-                            System.debug('✅ Record ' + recordIdStr + ' was COMPLETELY RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
-                            System.debug('   📊 RESOLUTION CONFIRMED: Record not found in any of the ' + ownerPayloads.size() + ' payload items');
                         } else {
                             stillMissingRecordsForOwner.add(recordIdStr);
-                            System.debug('⚠️  Record ' + recordIdStr + ' STILL HAS MISSING FIELDS for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
-                            System.debug('   📍 STILL EXISTS: Found in payload item ' + foundInPayloadId + ' (length: ' + payloadLength + ')');
                         }
                     }
                 }
 
-                System.debug('SUMMARY FOR OWNER ' + ownerId + ':');
-                System.debug('- Total updated records: ' + updatedRecordsForOwner.size() + ' → ' + updatedRecordsForOwner);
-                System.debug('- Completely resolved: ' + resolvedRecordsForOwner.size() + ' → ' + resolvedRecordsForOwner);
-                System.debug('- Still have missing fields: ' + stillMissingRecordsForOwner.size() + ' → ' + stillMissingRecordsForOwner);
-                System.debug('=== END DEBUGGING OWNER ' + ownerId + ' ===');
+
 
                 if (resolvedCount > 0) {
                     userToResolvedRecordsCount.put(ownerId, resolvedCount);
-                    System.debug('🎯 Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved - COUNT WILL DECREASE BY ' + resolvedCount);
                 }
             }
 

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -416,6 +416,8 @@
                                 userValidationMap.put(userIdStr, newValue);
                                 hasChanges = true;
                                 
+                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue + ' (Resolved ' + resolvedRecords + ' records completely)');
+                                
 
                             } catch (Exception e) {
                                 System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
@@ -518,6 +520,7 @@
 
                 if (resolvedCount > 0) {
                     userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                    System.debug('🎯 Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved - COUNT WILL DECREASE BY ' + resolvedCount);
                 }
             }
 

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -493,36 +493,55 @@
                         updatedRecordsForOwner.add(recordIdStr);
                         List<String> updatedFields = updatedFieldsByRecordId.get(recordId);
                         
-                        // Check if this record is still in ANY of the owner's payloads
-                        Boolean recordStillInAnyPayload = false;
+                        // Check if ANY of the updated fields are still missing in the payloads
+                        Boolean anyUpdatedFieldStillMissing = false;
+                        List<String> stillMissingUpdatedFields = new List<String>();
                         
                         for (Owner_based_Line_Items__c item : ownerPayloads) {
                             if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
                                 if (item.Payload__c.contains('"' + recordIdStr + '":')) {
-                                    recordStillInAnyPayload = true;
-                                    System.debug('   Record ' + recordIdStr + ' found in payload item ' + item.Id + ' (length: ' + item.Payload__c.length() + ')');
-                                    
-                                    // Extract what fields are still missing
+                                    // Extract the missing fields for this record
                                     Integer startPos = item.Payload__c.indexOf('"' + recordIdStr + '":');
                                     Integer arrayStart = item.Payload__c.indexOf('[', startPos);
                                     Integer arrayEnd = item.Payload__c.indexOf(']', arrayStart);
                                     if (arrayStart != -1 && arrayEnd != -1 && arrayEnd > arrayStart) {
                                         String fieldsArray = item.Payload__c.substring(arrayStart + 1, arrayEnd);
-                                        System.debug('   Still missing fields for ' + recordIdStr + ': ' + fieldsArray);
+                                        String[] missingFieldsArray = fieldsArray.replace('"', '').split(',');
+                                        
+                                        // Convert to lowercase for comparison
+                                        Set<String> missingFieldsSet = new Set<String>();
+                                        for (String field : missingFieldsArray) {
+                                            if (String.isNotBlank(field.trim())) {
+                                                missingFieldsSet.add(field.trim().toLowerCase());
+                                            }
+                                        }
+                                        
+                                        // Check if any of the updated fields are still in the missing fields
+                                        for (String updatedField : updatedFields) {
+                                            String updatedFieldLower = updatedField.toLowerCase();
+                                            if (missingFieldsSet.contains(updatedFieldLower)) {
+                                                anyUpdatedFieldStillMissing = true;
+                                                stillMissingUpdatedFields.add(updatedField);
+                                            }
+                                        }
+                                        
+                                        System.debug('   Record ' + recordIdStr + ' found in payload item ' + item.Id);
+                                        System.debug('   All missing fields in payload: ' + fieldsArray);
+                                        System.debug('   Updated fields that are still missing: ' + stillMissingUpdatedFields);
                                     }
-                                    break; // Found in one payload, no need to check others
+                                    break; // Found the record, no need to check other payloads
                                 }
                             }
                         }
                         
-                        if (!recordStillInAnyPayload) {
-                            // Record was completely resolved (not found in any payload)
+                        if (!anyUpdatedFieldStillMissing) {
+                            // All updated fields have been resolved (none of the updated fields are still missing)
                             resolvedCount++;
                             resolvedRecordsForOwner.add(recordIdStr);
-                            System.debug('✅ Record ' + recordIdStr + ' was COMPLETELY RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            System.debug('✅ Record ' + recordIdStr + ' - ALL UPDATED FIELDS RESOLVED for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
                         } else {
                             stillMissingRecordsForOwner.add(recordIdStr);
-                            System.debug('⚠️  Record ' + recordIdStr + ' STILL HAS MISSING FIELDS for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ')');
+                            System.debug('⚠️  Record ' + recordIdStr + ' - SOME UPDATED FIELDS STILL MISSING for owner ' + ownerId + ' (Updated fields: ' + updatedFields + ', Still missing: ' + stillMissingUpdatedFields + ')');
                         }
                     }
                 }

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -387,8 +387,7 @@
 
     /**
      * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
-     * after successful record updates. This method counts records that had missing fields
-     * and were successfully updated, checking if they still have missing fields after the update.
+     * after successful record updates. Simply counts updated records per owner and decreases the count.
      * @param trackerId The Object_Tracker__c record ID
      * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
      */
@@ -400,7 +399,7 @@
         try {
             // Get the Object_Tracker__c record with current User_Record_Summary__c
             List<Object_Tracker__c> trackers = [
-                SELECT Id, User_Record_Summary__c 
+                SELECT Id, Name, User_Record_Summary__c 
                 FROM Object_Tracker__c 
                 WHERE Id = :trackerId 
                 WITH SECURITY_ENFORCED
@@ -408,10 +407,13 @@
             ];
 
             if (trackers.isEmpty() || String.isBlank(trackers[0].User_Record_Summary__c)) {
+                System.debug('🔧 No tracker found or User_Record_Summary__c is blank for tracker: ' + trackerId);
                 return;
             }
 
             Object_Tracker__c tracker = trackers[0];
+            System.debug('🔧 Processing tracker: ' + tracker.Id + ' (' + tracker.Name + ')');
+            System.debug('🔧 Current User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
             
             // Parse the current user validation JSON
             Map<String, Object> userValidationMap;
@@ -425,13 +427,26 @@
             // Get owner information for the updated records
             Set<Id> recordIds = updatedFieldsByRecordId.keySet();
             Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
+            System.debug('🔧 Record to owner mapping: ' + recordToOwnerMap);
 
-            // Count how many records were completely resolved by checking payload
-            Map<Id, Integer> userToResolvedRecordsCount = getRecordsResolvedAfterUpdate(trackerId, updatedFieldsByRecordId, recordToOwnerMap);
+            // Count updated records per owner (simple approach)
+            Map<Id, Integer> userToUpdatedRecordsCount = new Map<Id, Integer>();
+            for (Id recordId : updatedFieldsByRecordId.keySet()) {
+                Id ownerId = recordToOwnerMap.get(recordId);
+                if (ownerId != null) {
+                    if (userToUpdatedRecordsCount.containsKey(ownerId)) {
+                        userToUpdatedRecordsCount.put(ownerId, userToUpdatedRecordsCount.get(ownerId) + 1);
+                    } else {
+                        userToUpdatedRecordsCount.put(ownerId, 1);
+                    }
+                }
+            }
+            
+            System.debug('🔧 Updated records count per user: ' + userToUpdatedRecordsCount);
 
             // Update the user validation counts
             Boolean hasChanges = false;
-            for (Id userId : userToResolvedRecordsCount.keySet()) {
+            for (Id userId : userToUpdatedRecordsCount.keySet()) {
                 String userIdStr = String.valueOf(userId);
                 if (userValidationMap.containsKey(userIdStr)) {
                     String currentValue = String.valueOf(userValidationMap.get(userIdStr));
@@ -441,17 +456,16 @@
                             try {
                                 Integer currentMissing = Integer.valueOf(parts[0]);
                                 Integer totalRecords = Integer.valueOf(parts[1]);
-                                Integer resolvedRecords = userToResolvedRecordsCount.get(userId);
+                                Integer updatedRecords = userToUpdatedRecordsCount.get(userId);
                                 
-                                // Decrease missing count by the number of records that were completely resolved
-                                Integer newMissing = Math.max(0, currentMissing - resolvedRecords);
+                                // Decrease missing count by the number of records updated
+                                Integer newMissing = Math.max(0, currentMissing - updatedRecords);
                                 
                                 String newValue = newMissing + '/' + totalRecords;
                                 userValidationMap.put(userIdStr, newValue);
                                 hasChanges = true;
                                 
-                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue + ' (Resolved ' + resolvedRecords + ' records completely)');
-                                
+                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue + ' (Updated ' + updatedRecords + ' records)');
 
                             } catch (Exception e) {
                                 System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
@@ -465,6 +479,7 @@
             if (hasChanges) {
                 tracker.User_Record_Summary__c = JSON.serialize(userValidationMap);
                 update tracker;
+                System.debug('🔧 Updated tracker User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
             }
 
         } catch (Exception e) {

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -1,0 +1,931 @@
+/**@class DynamicAgent
+ * @author Ayushi patel
+ * @created 2025-07-15
+ * @description
+ * - Construct class to get the details of object to agent
+ * - Construct class to save suggestions which is provided by agentforce
+ */
+ public without sharing class DynamicAgent {
+    private static Map<String, String> prefixToObjectMap = null;
+    @InvocableMethod(label='GetRecordInfo' description='Returns field values for a record when provided with its ID')
+    /**
+     * @description Fetch the object details based on recordIds
+     * @param recordIds List of record IDs
+     * @return List of response wrappers
+     */
+    public static List<ResponseWrapper> getRecordInfo(List<String> recordIds) {
+        if (recordIds == null || recordIds.isEmpty()) {
+            throw new AuraHandledException('recordId cannot be null or empty');
+        }
+
+        if (prefixToObjectMap == null) {
+            initializePrefixCache();
+        }
+
+        String recordId = recordIds[0];
+        if (recordId == null || recordId.length() < 3) {
+            throw new AuraHandledException('Invalid record ID format');
+        }
+
+        String objPrefix = recordId.substring(0, 3);
+        String objectApiName = prefixToObjectMap.get(objPrefix);
+        Schema.DescribeSObjectResult describe = Schema.getGlobalDescribe()
+            .get(objectApiName)
+            .getDescribe();
+
+        String objectLabel = describe.getLabel();
+        if (objectApiName == null) {
+            throw new AuraHandledException('Unable to determine object API name from recordId');
+        }
+
+        // Query the record
+        String query = buildDynamicQuery(objectApiName);
+        List<SObject> records = Database.query(query + ' WHERE Id = :recordId LIMIT 1');
+        if (records.isEmpty()) {
+            throw new AuraHandledException('No record found with ID: ' + recordId);
+        }
+
+        SObject record = records[0];
+
+        // Get Name field or fallback to first string field
+        String recordName = '';
+        Map<String, Schema.SObjectField> fields = Schema.getGlobalDescribe()
+            .get(objectApiName)
+            .getDescribe()
+            .fields.getMap();
+
+        if (fields.containsKey('Name') && record.get('Name') != null) {
+            recordName = String.valueOf(record.get('Name'));
+        } else {
+            for (String fieldApi : fields.keySet()) {
+                Schema.DescribeFieldResult fieldDescribe = fields.get(fieldApi).getDescribe();
+                if (fieldDescribe.getType() == Schema.DisplayType.String && record.get(fieldApi) != null) {
+                    recordName = String.valueOf(record.get(fieldApi));
+                    break;
+                }
+            }
+        }
+
+        ResponseWrapper response = new ResponseWrapper();
+        response.objectApiName = objectApiName;
+        response.objectLabel = objectLabel;
+        response.recordId = recordId;
+        response.recordName = recordName;
+        response.fieldValues = record;
+
+        return new List<ResponseWrapper> { response };
+            }
+
+    private static void initializePrefixCache() {
+        prefixToObjectMap = new Map<String, String>();
+        for (Schema.SObjectType objType : Schema.getGlobalDescribe().values()) {
+            Schema.DescribeSObjectResult objDescribe = objType.getDescribe();
+            String currentPrefix = objDescribe.getKeyPrefix();
+            if (currentPrefix != null) {
+                prefixToObjectMap.put(currentPrefix, objDescribe.getName());
+            }
+        }
+    }
+
+    private static String buildDynamicQuery(String objectApiName) {
+        Map<String, Schema.SObjectField> fields =
+            Schema.getGlobalDescribe().get(objectApiName).getDescribe().fields.getMap();
+
+        List<String> fieldNames = new List<String>(fields.keySet());
+        return 'SELECT ' + String.join(fieldNames, ', ') + ' FROM ' + objectApiName;
+    }
+
+    // Saves field suggestions for one or more records received from the AI agent on the UI.
+    //This method supports both single-record and bulk updates, depending on the input.
+
+    @AuraEnabled
+    public static SaveResultWrapper saveMultipleRecordFields(Map<String, Map<String, Object>> recordFieldValues) {
+        SaveResultWrapper result = new SaveResultWrapper();
+        result.fieldErrors = new Map<String, Map<String, String>>();
+        result.hasErrors = false;
+
+        if (recordFieldValues == null || recordFieldValues.isEmpty()) {
+            throw new AuraHandledException('No records provided for update.');
+        }
+
+        // Check if we're dealing with a large number of records
+        if (recordFieldValues.size() > 100) {
+            throw new AuraHandledException('Too many records provided for update. Maximum allowed is 100 records.');
+        }
+
+        Map<String, SObject> recordsToUpdate = new Map<String, SObject>();
+        Map<String, List<String>> updatedFieldsPerRecord = new Map<String, List<String>>();
+        Map<String, String> objectTypePerRecord = new Map<String, String>();
+
+        // Group field errors by recordId
+        for (String recordId : recordFieldValues.keySet()) {
+            Map<String, Object> fields = recordFieldValues.get(recordId);
+            if (String.isBlank(recordId) || fields == null || fields.isEmpty()){
+                continue;
+            }
+
+            Id recordIdObj = (Id) recordId;
+            String objectApiName = recordIdObj.getSObjectType().getDescribe().getName();
+            objectTypePerRecord.put(recordId, objectApiName);
+            SObject record = (SObject) Type.forName('Schema.' + objectApiName).newInstance();
+            record.put('Id', recordId);
+
+            Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe().get(objectApiName).getDescribe().fields.getMap();
+            List<String> updatedFields = new List<String>();
+            Map<String, String> fieldErrors = new Map<String, String>();
+
+            for (String fieldApi : fields.keySet()) {
+                try {
+                    if (!fieldMap.containsKey(fieldApi)){
+                        continue;
+                    }
+
+                    Object value = fields.get(fieldApi);
+                    if (value == null || String.valueOf(value).trim() == ''){
+                        continue;
+                    }
+                    Schema.DisplayType fieldType = fieldMap.get(fieldApi).getDescribe().getType();
+                    Object convertedValue = convertValueByType(value, fieldType);
+
+                    if ((fieldType == Schema.DisplayType.String || fieldType == Schema.DisplayType.TextArea) && convertedValue != null) {
+                        Integer maxLength = fieldMap.get(fieldApi).getDescribe().getLength();
+                        if (String.valueOf(convertedValue).length() > maxLength) {
+                            fieldErrors.put(fieldApi, 'Input Value is too long (max ' + maxLength + ' characters)');
+                            continue;
+                        }
+                    }
+
+                    if ((fieldType == Schema.DisplayType.Currency || fieldType == Schema.DisplayType.Double) && convertedValue != null) {
+                        String strVal = String.valueOf(convertedValue).trim();
+                        Schema.DescribeFieldResult d = fieldMap.get(fieldApi).getDescribe();
+
+                        try {
+                            Decimal dVal = Decimal.valueOf(strVal); // Will throw if invalid
+
+                            Integer digitsBefore = strVal.contains('.') ? strVal.split('\\.')[0].replace('-', '').length() : strVal.replace('-', '').length();
+                            Integer digitsAfter = strVal.contains('.') ? strVal.split('\\.')[1].length() : 0;
+
+                            if (digitsBefore + digitsAfter > d.getPrecision()) {
+                                fieldErrors.put(fieldApi, 'Value exceeds : maximum ' + d.getPrecision() + ' digits allowed including decimals');
+
+                                continue;
+                            }
+                        } catch (Exception e) {
+                            fieldErrors.put(fieldApi, 'Invalid number format.');
+                            continue;
+                        }
+                    }
+                    if (fieldType == Schema.DisplayType.Email && convertedValue != null) {
+                        if (!Pattern.matches('^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$', String.valueOf(convertedValue))) {
+                            fieldErrors.put(fieldApi, 'Invalid email format.');
+                            continue;
+                        }
+                    }
+
+                    if (fieldType == Schema.DisplayType.Phone && convertedValue != null) {
+                        String phoneDigits = String.valueOf(convertedValue).replaceAll('[^\\d]', '');
+
+                        if (!Pattern.matches('^[\\d\\-\\+()\\s]+$', String.valueOf(convertedValue))) {
+                            fieldErrors.put(fieldApi, 'Invalid phone number format.');
+                            continue;
+                        }
+                        if (phoneDigits.length() > 10 || phoneDigits.length() < 10) {
+                            fieldErrors.put(fieldApi, 'Phone number must be exactly 10 digits');
+                            continue;
+                        }
+                    }
+
+                    if (fieldType == Schema.DisplayType.Percent && convertedValue != null) {
+                        Decimal percentValue;
+                        try {
+                            percentValue = Decimal.valueOf(String.valueOf(convertedValue));
+                        } catch (Exception e) {
+                            fieldErrors.put(fieldApi, 'Invalid percent value.');
+                            continue;
+                        }
+                        if (percentValue < 0 || percentValue > 100) {
+                            fieldErrors.put(fieldApi, 'Percent must be between 0 and 100');
+                            continue;
+                        }
+                    }
+                   if (fieldApi != null &&
+                        (fieldApi.toLowerCase().contains('website') || fieldType == Schema.DisplayType.Url)) {
+
+                        String urlStr = convertedValue == null ? '' : String.valueOf(convertedValue).trim();
+
+                        // Securely get object describe
+                        Map<String, Schema.SObjectType> globalDescribe = Schema.getGlobalDescribe();
+                        if (!globalDescribe.containsKey(objectApiName)) {
+                            continue; // Invalid object name, skip
+                        }
+                        Schema.DescribeSObjectResult objDescribe = globalDescribe.get(objectApiName).getDescribe();
+
+                        // Securely get field describe
+                        Map<String, Schema.SObjectField> fieldsMap = objDescribe.fields.getMap();
+                        if (!fieldsMap.containsKey(fieldApi)) {
+                            continue; // Invalid field name, skip
+                        }
+                        Integer maxUrlLength = fieldsMap.get(fieldApi).getDescribe().getLength();
+
+                        // Check blank or too long
+                        if (String.isBlank(urlStr) || urlStr.length() > maxUrlLength) {
+                            fieldErrors.put(fieldApi, 'URL is too long. Max length: ' + maxUrlLength);
+                            continue;
+                        }
+
+                        // Allow multi-subdomain URLs like Salesforce Lightning domains
+                        String regex = '^(https?://)?([\\w.-]+\\.)+[a-zA-Z]{2,}(:[0-9]+)?(/.*)?$';
+                        if (!Pattern.matches(regex, urlStr)) {
+                            fieldErrors.put(fieldApi, 'Invalid URL format.');
+                            continue;
+                        }
+                    }
+
+                    record.put(fieldApi, convertedValue);
+                    updatedFields.add(fieldApi);
+
+                } catch (Exception e) {
+                    fieldErrors.put(fieldApi, 'Invalid value: ' + e.getMessage());
+                }
+            }
+
+            if (!fieldErrors.isEmpty()) {
+                result.fieldErrors.put(recordId, fieldErrors);
+                //throw new AuraHandledException(JSON.serialize(fieldErrors));
+            }
+
+            if (!updatedFields.isEmpty()) {
+                recordsToUpdate.put(recordId, record);
+                updatedFieldsPerRecord.put(recordId, updatedFields);
+            }
+        }
+
+        // Bulk DML with error mapping
+        if (!recordsToUpdate.isEmpty()) {
+            try {
+                update recordsToUpdate.values();
+            } catch (DmlException dmlEx) {
+                for (Integer i = 0; i < dmlEx.getNumDml(); i++) {
+                    String msg = dmlEx.getDmlMessage(i);
+                    Id dmlRecordId = (Id) dmlEx.getDmlId(i);
+                    String recId = String.valueOf(dmlRecordId);
+                    String fieldMatch = 'Unknown';
+                    String fieldType = 'UNKNOWN';
+                    String finalMsg = msg;
+
+                    // Try to extract field from [FieldName]
+                    Matcher m = Pattern.compile('\\[([a-zA-Z0-9_]+)\\]').matcher(msg);
+                    if (m.find()) {
+                        fieldMatch = m.group(1);
+                    }
+
+                    // Handle duplicate errors specially
+                    if (msg != null && msg.containsIgnoreCase('duplicate value')) {
+                        List<String> fields = new List<String>();
+                        for (String part : msg.split(',')) {
+                            part = part.trim();
+                            Integer idx = part.indexOf(' duplicates value');
+                            if (idx > 0) {
+                                String apiName = part.substring(0, idx).trim();
+                                String label = apiName.replaceAll('__c', '').replaceAll('_', ' ').trim();
+                                fields.add(label);
+                            }
+                        }
+
+                        finalMsg = fields.isEmpty()
+                            ? 'Duplicate value error. Some fields must be unique.'
+                            : 'The field' + (fields.size() > 1 ? 's ' : ' ') +
+                                String.join(fields, ' and ') +
+                                ' must be unique. Duplicate values were found.';
+
+                        fieldMatch = 'Unknown'; // To force top-level toast
+                    } else {
+                        // Try to get field type info if available
+                        if (objectTypePerRecord.containsKey(recId)) {
+                            Map<String, Schema.SObjectField> fMap = Schema.getGlobalDescribe()
+                                .get(objectTypePerRecord.get(recId)).getDescribe().fields.getMap();
+                            if (fMap.containsKey(fieldMatch)) {
+                                fieldType = fMap.get(fieldMatch).getDescribe().getType().name();
+                            }
+                        }
+
+                        Object val = recordFieldValues.get(recId).get(fieldMatch);
+                        // finalMsg = 'Invalid "' + String.valueOf(val) + '" for ' + fieldType + ': ' + msg;
+                        finalMsg = msg;
+                    }
+
+                    // Populate error map
+                    if (!result.fieldErrors.containsKey(recId)) {
+                        result.fieldErrors.put(recId, new Map<String, String>());
+                    }
+                    result.fieldErrors.get(recId).put(fieldMatch, finalMsg);
+                }
+            }
+        }
+
+        // Remove updated fields from payloads only if record had no errors
+        Map<Id, List<String>> cleanUpdatedMap = new Map<Id, List<String>>();
+        for (String recordId : updatedFieldsPerRecord.keySet()) {
+            if (!result.fieldErrors.containsKey(recordId)) {
+                cleanUpdatedMap.put((Id) recordId, updatedFieldsPerRecord.get(recordId));
+            }
+        }
+
+        if (!cleanUpdatedMap.isEmpty()) {
+            Set<String> objectNames = new Set<String>(objectTypePerRecord.values());
+            for (String obj : objectNames) {
+                List<Object_Tracker__c> trackers = [
+                    SELECT Id FROM Object_Tracker__c
+                    WHERE Name = :obj
+                    ORDER BY CreatedDate DESC LIMIT 1
+                ];
+                if (!trackers.isEmpty()) {
+                    removeUpdatedFieldsFromPayloadBatch(trackers[0].Id, cleanUpdatedMap);
+                    // Update user validation counts after successful updates
+                    updateUserValidationCounts(trackers[0].Id, cleanUpdatedMap);
+                }
+            }
+        }
+
+        result.hasErrors = !result.fieldErrors.isEmpty();
+        return result;
+    }
+
+    /**
+     * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
+     * after successful record updates. Decreases the missing count for users who had records updated.
+     * @param trackerId The Object_Tracker__c record ID
+     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
+     */
+    public static void updateUserValidationCounts(Id trackerId, Map<Id, List<String>> updatedFieldsByRecordId) {
+        if (trackerId == null || updatedFieldsByRecordId == null || updatedFieldsByRecordId.isEmpty()) {
+            return;
+        }
+
+        try {
+            // Get the Object_Tracker__c record with current User_Record_Summary__c
+            List<Object_Tracker__c> trackers = [
+                SELECT Id, User_Record_Summary__c 
+                FROM Object_Tracker__c 
+                WHERE Id = :trackerId 
+                WITH SECURITY_ENFORCED
+                LIMIT 1
+            ];
+
+            if (trackers.isEmpty() || String.isBlank(trackers[0].User_Record_Summary__c)) {
+                return;
+            }
+
+            Object_Tracker__c tracker = trackers[0];
+            
+            // Parse the current user validation JSON
+            Map<String, Object> userValidationMap;
+            try {
+                userValidationMap = (Map<String, Object>) JSON.deserializeUntyped(tracker.User_Record_Summary__c);
+            } catch (Exception e) {
+                System.debug('Error parsing User_Record_Summary__c JSON: ' + e.getMessage());
+                return;
+            }
+
+            // Get owner information for the updated records
+            Set<Id> recordIds = updatedFieldsByRecordId.keySet();
+            Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
+
+            // Count how many fields were updated per user
+            Map<Id, Integer> userToUpdatedFieldsCount = new Map<Id, Integer>();
+            for (Id recordId : updatedFieldsByRecordId.keySet()) {
+                Id ownerId = recordToOwnerMap.get(recordId);
+                if (ownerId != null) {
+                    Integer fieldCount = updatedFieldsByRecordId.get(recordId).size();
+                    if (userToUpdatedFieldsCount.containsKey(ownerId)) {
+                        userToUpdatedFieldsCount.put(ownerId, userToUpdatedFieldsCount.get(ownerId) + fieldCount);
+                    } else {
+                        userToUpdatedFieldsCount.put(ownerId, fieldCount);
+                    }
+                }
+            }
+
+            // Update the user validation counts
+            Boolean hasChanges = false;
+            for (Id userId : userToUpdatedFieldsCount.keySet()) {
+                String userIdStr = String.valueOf(userId);
+                if (userValidationMap.containsKey(userIdStr)) {
+                    String currentValue = String.valueOf(userValidationMap.get(userIdStr));
+                    if (currentValue.contains('/')) {
+                        String[] parts = currentValue.split('/');
+                        if (parts.size() == 2) {
+                            try {
+                                Integer currentMissing = Integer.valueOf(parts[0]);
+                                Integer totalRecords = Integer.valueOf(parts[1]);
+                                Integer updatedFields = userToUpdatedFieldsCount.get(userId);
+                                
+                                // Decrease missing count by the number of fields updated
+                                Integer newMissing = Math.max(0, currentMissing - updatedFields);
+                                
+                                String newValue = newMissing + '/' + totalRecords;
+                                userValidationMap.put(userIdStr, newValue);
+                                hasChanges = true;
+                                
+                                System.debug('Updated user validation for ' + userIdStr + ': ' + currentValue + ' -> ' + newValue);
+                            } catch (Exception e) {
+                                System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Update the Object_Tracker__c record if there were changes
+            if (hasChanges) {
+                tracker.User_Record_Summary__c = JSON.serialize(userValidationMap);
+                update tracker;
+                System.debug('Updated Object_Tracker__c User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
+            }
+
+        } catch (Exception e) {
+            System.debug('Error in updateUserValidationCounts: ' + e.getMessage());
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+
+    /**
+     * @description Get owner IDs for a set of record IDs
+     * @param recordIds Set of record IDs
+     * @return Map of record ID to owner ID
+     */
+    private static Map<Id, Id> getRecordOwners(Set<Id> recordIds) {
+        Map<Id, Id> recordToOwnerMap = new Map<Id, Id>();
+        
+        if (recordIds.isEmpty()) {
+            return recordToOwnerMap;
+        }
+
+        // Group records by object type for efficient querying
+        Map<String, Set<Id>> objectTypeToRecordIds = new Map<String, Set<Id>>();
+        for (Id recordId : recordIds) {
+            String objectType = recordId.getSObjectType().getDescribe().getName();
+            if (!objectTypeToRecordIds.containsKey(objectType)) {
+                objectTypeToRecordIds.put(objectType, new Set<Id>());
+            }
+            objectTypeToRecordIds.get(objectType).add(recordId);
+        }
+
+        // Query each object type separately
+        for (String objectType : objectTypeToRecordIds.keySet()) {
+            try {
+                Set<Id> ids = objectTypeToRecordIds.get(objectType);
+                String soql = 'SELECT Id, OwnerId FROM ' + String.escapeSingleQuotes(objectType) + ' WHERE Id IN :ids WITH SECURITY_ENFORCED';
+                List<SObject> records = Database.query(soql);
+                
+                for (SObject record : records) {
+                    recordToOwnerMap.put((Id)record.get('Id'), (Id)record.get('OwnerId'));
+                }
+            } catch (Exception e) {
+                System.debug('Error querying owners for object type ' + objectType + ': ' + e.getMessage());
+            }
+        }
+
+        return recordToOwnerMap;
+    }
+
+    /**
+* Batch update: Remove updated fields from Owner_based_Line_Items__c.Payload__c for all updated records/fields.
+* Called after successful record update(s) from UI.
+*/
+    public static void removeUpdatedFieldsFromPayloadBatch(
+        Id trackerId,
+        Map<Id, List<String>> updatedFieldsByRecordId
+    ) {
+        if (trackerId == null || updatedFieldsByRecordId == null || updatedFieldsByRecordId.isEmpty()){
+            return;
+        }
+
+        // If dealing with a large number of records, use batch processing
+        if (updatedFieldsByRecordId.size() > 50) {
+            processLargePayloadUpdateBatch(trackerId, updatedFieldsByRecordId);
+            return;
+        }
+
+        // Group recordIds by ownerId for efficient SOQL
+        Set<Id> recordIds = new Set<Id>(updatedFieldsByRecordId.keySet());
+
+        // Group recordIds by object type
+        Map<String, Set<Id>> objectTypeToRecordIds = new Map<String, Set<Id>>();
+        for (Id recId : recordIds) {
+            String objApi = recId.getSObjectType().getDescribe().getName();
+            if (!objectTypeToRecordIds.containsKey(objApi)){
+                objectTypeToRecordIds.put(objApi, new Set<Id>());
+            }
+            objectTypeToRecordIds.get(objApi).add(recId);
+        }
+
+        // Query records to get OwnerId for a single object type to reduce heap usage
+        Map<Id, SObject> recs = new Map<Id, SObject>();
+        if (!objectTypeToRecordIds.isEmpty()) {
+            String objApi = objectTypeToRecordIds.keySet().iterator().next();
+            Set<Id> ids = objectTypeToRecordIds.get(objApi);
+            if (!ids.isEmpty()) {
+                String soql = String.escapeSingleQuotes('SELECT Id, OwnerId FROM ' + objApi + ' WHERE Id IN :ids');
+                recs.putAll(new Map<Id, SObject>(Database.query(soql)));
+            }
+        }
+
+        // Map ownerId to recordIds
+        Map<Id, List<Id>> ownerToRecordIds = new Map<Id, List<Id>>();
+        for (Id recId : recs.keySet()) {
+            Id ownerId = (Id) recs.get(recId).get('OwnerId');
+            if (!ownerToRecordIds.containsKey(ownerId)){
+                ownerToRecordIds.put(ownerId, new List<Id>());
+            }
+            ownerToRecordIds.get(ownerId).add(recId);
+        }
+
+        // Query all Owner_based_Line_Items__c for these owners/tracker
+        List<Owner_based_Line_Items__c> items = [
+            SELECT Id, OwnerRecordId__c, Payload__c
+            FROM Owner_based_Line_Items__c
+            WHERE OwnerRecordId__c IN :ownerToRecordIds.keySet()
+            AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
+            WITH SECURITY_ENFORCED
+        ];
+
+        List<Owner_based_Line_Items__c> toUpdate = new List<Owner_based_Line_Items__c>();
+
+        // Process each item once to avoid multiple deserializations
+        for (Owner_based_Line_Items__c item : items) {
+            if (String.isBlank(item.Payload__c)){
+                continue;
+            }
+
+            // Check payload size - use string operations for large payloads instead of skipping
+            Boolean isLargePayload = item.Payload__c.length() > 25000;
+            if (isLargePayload) {
+                System.debug('Processing large payload with string operations: ' + item.Id + ' size: ' + item.Payload__c.length());
+            }
+
+            // Process payload; prefer small-payload Map-based path, fall back to string ops for larger payloads
+            String payloadStr = item.Payload__c;
+            Boolean changed = false;
+
+            try {
+
+                         // Try Map-based approach first for small payloads only
+             if (!isLargePayload && item.Payload__c.length() <= 12000) {
+                try {
+                    Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(payloadStr);
+                    if (payload != null) {
+                        Integer beforeCount = payload.size();
+                        List<Id> recList = ownerToRecordIds.containsKey(item.OwnerRecordId__c) ? ownerToRecordIds.get(item.OwnerRecordId__c) : new List<Id>();
+                        for (Id recId : recList) {
+                            String recKey = (String)recId;
+                            if (payload.containsKey(recKey)) {
+                                List<Object> missingFieldsObj = (List<Object>) payload.get(recKey);
+                                List<String> missingFields = new List<String>();
+                                if (missingFieldsObj != null) {
+                                    for (Object o : missingFieldsObj) {
+                                        missingFields.add(String.valueOf(o));
+                                    }
+                                }
+                                List<String> upd = updatedFieldsByRecordId.get(recId);
+                                if (upd != null) {
+                                    for (String field : upd) {
+                                        for (Integer i = missingFields.size() - 1; i >= 0; i--) {
+                                            if (missingFields[i] == field) {
+                                                missingFields.remove(i);
+                                            }
+                                        }
+                                    }
+                                }
+                                if (missingFields.isEmpty()) {
+                                    payload.remove(recKey);
+                                } else {
+                                    List<Object> newMissingFieldsObj = new List<Object>();
+                                    for (String s : missingFields) {
+                                        newMissingFieldsObj.add(s);
+                                    }
+                                    payload.put(recKey, newMissingFieldsObj);
+                                }
+                                changed = true;
+                            }
+                        }
+                        if (changed) {
+                            Integer afterCount = payload.size();
+                            Integer removedRecords = beforeCount - afterCount;
+                            item.Payload__c = payload.isEmpty() ? null : JSON.serialize(payload);
+                            payloadStr = item.Payload__c == null ? '{}' : item.Payload__c;
+                            toUpdate.add(item);
+                            System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (map) before=' + beforeCount + ' after=' + afterCount + ' removed=' + removedRecords);
+                            // Avoid processing the same item again via string path which can cause duplicate DML IDs
+                            continue;
+                        }
+                    }
+                } catch (Exception ex) {
+                    changed = false; // fallback to string path below
+                }
+            }
+
+            List<Id> ownerRecIds = ownerToRecordIds.containsKey(item.OwnerRecordId__c) ? ownerToRecordIds.get(item.OwnerRecordId__c) : new List<Id>();
+            Integer removedRecordsStr = 0;
+            Integer beforeCountStr = 0;
+            if (String.isNotBlank(payloadStr)) {
+                Integer idxScan = 0;
+                String marker = '\":[\"';
+                while (true) {
+                    Integer pos = payloadStr.indexOf(marker, idxScan);
+                    if (pos == -1) break;
+                    beforeCountStr++;
+                    idxScan = pos + marker.length();
+                }
+            }
+            for (Id recId : ownerRecIds) {
+                if (changed) { break; }
+                String recIdStr = (String)recId;
+                                if (payloadStr.contains('"' + recIdStr + '"')) {
+                    // Find the record entry in the JSON string using Apex methods
+                    String searchKey = '"' + recIdStr + '":';
+                    Integer startIndex = payloadStr.indexOf(searchKey);
+
+                    if (startIndex != -1) {
+                        // Find the opening bracket after the key
+                        Integer bracketStart = payloadStr.indexOf('[', startIndex);
+                        if (bracketStart != -1) {
+                            // Find the closing bracket
+                            Integer bracketEnd = payloadStr.indexOf(']', bracketStart);
+                            if (bracketEnd != -1) {
+                                // Extract the fields string
+                                String fieldsStr = payloadStr.substring(bracketStart + 1, bracketEnd);
+                                List<String> missingFields = new List<String>();
+
+                                // Parse fields from the string
+                                if (String.isNotBlank(fieldsStr)) {
+                                    String[] fieldParts = fieldsStr.split(',');
+                                    for (String field : fieldParts) {
+                                        field = field.trim().replaceAll('"', '');
+                                        if (String.isNotBlank(field)) {
+                                            missingFields.add(field);
+                                        }
+                                    }
+                                }
+
+                                // Remove updated fields
+                                for (String field : updatedFieldsByRecordId.get(recId)) {
+                                    // Remove all occurrences of the field
+                                    for (Integer i = missingFields.size() - 1; i >= 0; i--) {
+                                        if (missingFields[i] == field) {
+                                            missingFields.remove(i);
+                                        }
+                                    }
+                                }
+
+                                // Reconstruct the JSON string
+                                if (missingFields.isEmpty()) {
+                                    // Remove entire record entry
+                                    String beforeRecord = payloadStr.substring(0, startIndex);
+                                    String afterRecord = payloadStr.substring(bracketEnd + 1);
+
+                                    // Remove trailing comma if present
+                                    if (beforeRecord.endsWith(',')) {
+                                        beforeRecord = beforeRecord.substring(0, beforeRecord.length() - 1);
+                                    }
+                                    if (afterRecord.startsWith(',')) {
+                                        afterRecord = afterRecord.substring(1);
+                                    }
+
+                                    payloadStr = beforeRecord + afterRecord;
+                                    removedRecordsStr++;
+                                } else {
+                                    // Update the fields array
+                                    String newFieldsStr = '"' + String.join(missingFields, '","') + '"';
+                                    String beforeBracket = payloadStr.substring(0, bracketStart + 1);
+                                    String afterBracket = payloadStr.substring(bracketEnd);
+                                    payloadStr = beforeBracket + newFieldsStr + afterBracket;
+                                }
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+                        // Clean up the JSON string
+            if (changed) {
+                // Remove trailing commas and clean up using Apex methods
+                payloadStr = payloadStr.replace(',}', '}');
+                payloadStr = payloadStr.replace(',]', ']');
+                payloadStr = payloadStr.replace('{,}', '{}');
+
+                if (payloadStr.trim() == '{}' || payloadStr.trim() == '' || payloadStr.trim() == '[]') {
+                    item.Payload__c = null;
+                } else {
+                    item.Payload__c = payloadStr;
+                }
+                toUpdate.add(item);
+                Integer afterCountStr = 0;
+                if (String.isNotBlank(item.Payload__c)) {
+                    Integer idxScan2 = 0;
+                    String marker2 = '\":[\"';
+                    while (true) {
+                        Integer pos2 = item.Payload__c.indexOf(marker2, idxScan2);
+                        if (pos2 == -1) break;
+                        afterCountStr++;
+                        idxScan2 = pos2 + marker2.length();
+                    }
+                }
+                System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (string) before=' + beforeCountStr + ' after=' + afterCountStr + ' removed=' + removedRecordsStr);
+            }
+            } catch (Exception e) {
+                System.debug('Error processing payload for item ' + item.Id + ': ' + e.getMessage());
+                // Skip this item if there's an error
+                continue;
+            }
+        }
+
+        if (!toUpdate.isEmpty()) {
+            update toUpdate;
+        }
+    }
+
+    /**
+     * Process large payload updates in smaller batches to avoid heap size issues
+     */
+    private static void processLargePayloadUpdateBatch(
+        Id trackerId,
+        Map<Id, List<String>> updatedFieldsByRecordId
+    ) {
+        // Process in chunks of 25 records at a time (reduced for better memory management)
+        Integer batchSize = 25;
+        List<Id> recordIds = new List<Id>(updatedFieldsByRecordId.keySet());
+
+        for (Integer i = 0; i < recordIds.size(); i += batchSize) {
+            Integer endIndex = Math.min(i + batchSize, recordIds.size());
+
+            Map<Id, List<String>> batchUpdatedFields = new Map<Id, List<String>>();
+            for (Integer j = i; j < endIndex; j++) {
+                Id recordId = recordIds[j];
+                batchUpdatedFields.put(recordId, updatedFieldsByRecordId.get(recordId));
+            }
+
+            // Process this batch
+            removeUpdatedFieldsFromPayloadBatch(trackerId, batchUpdatedFields);
+
+            // Clear variables to free up heap
+            batchUpdatedFields.clear();
+
+            // Force garbage collection by clearing the list
+            recordIds.clear();
+            recordIds = new List<Id>(updatedFieldsByRecordId.keySet());
+        }
+    }
+
+    public static Object convertValueByType(Object value, Schema.DisplayType fieldType) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            switch on fieldType {
+                when CURRENCY, DOUBLE, PERCENT {
+                    if (value instanceof String) {
+                        String clean = ((String)value).replace(',', '');
+                        return String.isBlank(clean) ? null : Decimal.valueOf(clean);
+                    }
+                    return value;
+                }
+                when INTEGER {
+                    if (value instanceof String) {
+                        String clean = ((String)value).replace(',', '');
+                        return String.isBlank(clean) ? null : Integer.valueOf(clean);
+                    }
+                    return value;
+                }
+                when LONG {
+                    if (value instanceof String) {
+                        String clean = ((String)value).replace(',', '');
+                        return String.isBlank(clean) ? null : Long.valueOf(clean);
+                    }
+                    return value;
+                }
+                when BOOLEAN {
+                    if (value instanceof String) {
+                        return Boolean.valueOf((String)value);
+                    }
+                    return value;
+                }
+                when DATE {
+                    if (value instanceof String) {
+                        return String.isBlank((String)value) ? null : Date.valueOf((String)value);
+                    }
+                    return value;
+                }
+              when DATETIME {
+    if (value instanceof String) {
+        String dtStr = (String) value;
+        if (String.isBlank(dtStr)) {
+            return null;
+        }
+
+        if (dtStr.contains('T')) {
+            String[] parts = dtStr.split('T');
+            if (parts.size() == 2) {
+                String datePart = parts[0];
+                String timePart = parts[1];
+                Boolean isUTC = false;
+
+                // Detect UTC indicator 'Z'
+                if (timePart.endsWith('Z')) {
+                    timePart = timePart.substring(0, timePart.length() - 1);
+                    isUTC = true;
+                }
+
+                // Remove milliseconds if present
+                if (timePart.contains('.')) {
+                    timePart = timePart.split('\\.')[0];
+                }
+
+                DateTime parsed = DateTime.valueOf(datePart + ' ' + timePart);
+
+                // Convert from UTC to user's timezone if 'Z' was present
+                if (isUTC) {
+                    Integer offsetSeconds = Math.mod(UserInfo.getTimeZone().getOffset(parsed), 86400000) / 1000;
+                    parsed = parsed.addSeconds(offsetSeconds);
+                }
+
+                return parsed;
+            }
+        }
+
+        // Fallback if it's already in a valid DateTime format
+        return DateTime.valueOf(dtStr);
+    }
+    return value;
+}
+
+
+
+                when TIME {
+                    if (value instanceof String) {
+                        String timeStr = ((String)value).trim().toLowerCase();
+
+                        if (String.isBlank(timeStr)){
+                            return null;
+                        }
+
+                        // Handle AM/PM formats like "12:00 am"
+                        Boolean isPM = timeStr.contains('pm');
+                        Boolean isAM = timeStr.contains('am');
+
+                        timeStr = timeStr.replaceAll('[^0-9:]', '');
+
+                        List<String> parts = timeStr.split(':');
+                        if (parts.size() >= 2) {
+                            Integer hours = Integer.valueOf(parts[0]);
+                            Integer minutes = Integer.valueOf(parts[1]);
+                            Integer seconds = (parts.size() == 3) ? Integer.valueOf(parts[2]) : 0;
+
+                            if (isPM && hours < 12){
+                                 hours += 12;
+                                }
+                            if (isAM && hours == 12){
+                            hours = 0;
+                        }
+
+                            return Time.newInstance(hours, minutes, seconds, 0);
+                        }
+                    }
+
+                    return value;
+                }
+
+
+                when else {
+                    return value;
+                }
+            }
+        } catch (Exception e) {
+            return value;
+        }
+    }
+    public class ResponseWrapper {
+        @InvocableVariable(label='Object API Name')
+        public String objectApiName;
+
+        @InvocableVariable(label='Object Label')
+        public String objectLabel;
+
+        @InvocableVariable(label='Record ID')
+        public String recordId;
+
+        @InvocableVariable(label='Record Name')
+        public String recordName;
+
+        @InvocableVariable(label='Field Values')
+        public SObject fieldValues;
+
+        @InvocableVariable(label='Field label')
+        public String fieldLabels;
+    }
+    public class SaveResultWrapper {
+        @AuraEnabled public Boolean hasErrors;
+        @AuraEnabled public Map<String, Map<String, String>> fieldErrors;
+    }
+}

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -353,8 +353,8 @@
 
     /**
      * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
-     * after successful record updates. This method uses the removeUpdatedFieldsFromPayloadBatch
-     * tracking to determine exactly how many records were completely resolved.
+     * after successful record updates. This method counts records that had missing fields
+     * and were successfully updated, checking if they still have missing fields after the update.
      * @param trackerId The Object_Tracker__c record ID
      * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
      */
@@ -392,8 +392,8 @@
             Set<Id> recordIds = updatedFieldsByRecordId.keySet();
             Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
 
-            // Use the global tracking variable to get accurate resolved record counts
-            Map<Id, Integer> userToResolvedRecordsCount = getActualResolvedRecordsCount(recordToOwnerMap);
+            // Count how many records were completely resolved by checking payload
+            Map<Id, Integer> userToResolvedRecordsCount = getRecordsResolvedAfterUpdate(trackerId, updatedFieldsByRecordId, recordToOwnerMap);
 
             // Update the user validation counts
             Boolean hasChanges = false;
@@ -432,33 +432,75 @@
                 System.debug('Updated Object_Tracker__c User_Record_Summary__c: ' + tracker.User_Record_Summary__c);
             }
 
-            // Clear the tracking variable after use
-            resolvedRecordsTracker.clear();
-
         } catch (Exception e) {
             System.debug('Error in updateUserValidationCounts: ' + e.getMessage());
             // Don't throw exception to avoid breaking the main flow
         }
     }
 
-    // Static variable to track resolved records during payload processing
-    private static Map<Id, Integer> resolvedRecordsTracker = new Map<Id, Integer>();
-
     /**
-     * @description Get the actual resolved records count from the tracking variable
+     * @description Count how many records were completely resolved (no longer in payload) per user
+     * by checking the current payload after updates have been processed
+     * @param trackerId The Object_Tracker__c record ID
+     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
      * @param recordToOwnerMap Map of record ID to owner ID
      * @return Map of user ID to count of completely resolved records
      */
-    private static Map<Id, Integer> getActualResolvedRecordsCount(Map<Id, Id> recordToOwnerMap) {
+    private static Map<Id, Integer> getRecordsResolvedAfterUpdate(
+        Id trackerId, 
+        Map<Id, List<String>> updatedFieldsByRecordId, 
+        Map<Id, Id> recordToOwnerMap
+    ) {
         Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
         
-        // Use the tracked data from removeUpdatedFieldsFromPayloadBatch
-        for (Id ownerId : resolvedRecordsTracker.keySet()) {
-            Integer resolvedCount = resolvedRecordsTracker.get(ownerId);
-            if (resolvedCount > 0) {
-                userToResolvedRecordsCount.put(ownerId, resolvedCount);
-                System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records actually resolved (from tracker)');
+        try {
+            // Get owner IDs for the updated records
+            Set<Id> ownerIds = new Set<Id>(recordToOwnerMap.values());
+            
+            // Query Owner_based_Line_Items__c to check current payload state
+            List<Owner_based_Line_Items__c> items = [
+                SELECT Id, OwnerRecordId__c, Payload__c
+                FROM Owner_based_Line_Items__c
+                WHERE OwnerRecordId__c IN :ownerIds
+                AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
+                WITH SECURITY_ENFORCED
+            ];
+
+            // For each owner, check which updated records are no longer in their payload
+            for (Owner_based_Line_Items__c item : items) {
+                Id ownerId = item.OwnerRecordId__c;
+                Integer resolvedCount = 0;
+
+                // Check each record that was updated for this owner
+                for (Id recordId : updatedFieldsByRecordId.keySet()) {
+                    if (recordToOwnerMap.get(recordId) == ownerId) {
+                        // Check if this record is no longer in the payload (completely resolved)
+                        String recordIdStr = String.valueOf(recordId);
+                        Boolean recordStillInPayload = false;
+                        
+                        if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
+                            // More precise check - look for the exact record key pattern
+                            recordStillInPayload = item.Payload__c.contains('"' + recordIdStr + '":');
+                        }
+                        
+                        if (!recordStillInPayload) {
+                            // Record was completely resolved (all missing fields fixed)
+                            resolvedCount++;
+                            System.debug('Record ' + recordIdStr + ' was completely resolved for owner ' + ownerId);
+                        } else {
+                            System.debug('Record ' + recordIdStr + ' still has missing fields for owner ' + ownerId);
+                        }
+                    }
+                }
+
+                if (resolvedCount > 0) {
+                    userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                    System.debug('Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved');
+                }
             }
+
+        } catch (Exception e) {
+            System.debug('Error in getRecordsResolvedAfterUpdate: ' + e.getMessage());
         }
 
         return userToResolvedRecordsCount;
@@ -631,15 +673,7 @@
                             payloadStr = item.Payload__c == null ? '{}' : item.Payload__c;
                             toUpdate.add(item);
                             
-                            // Track the actual number of records resolved for this owner
-                            if (removedRecords > 0) {
-                                if (resolvedRecordsTracker.containsKey(item.OwnerRecordId__c)) {
-                                    resolvedRecordsTracker.put(item.OwnerRecordId__c, 
-                                        resolvedRecordsTracker.get(item.OwnerRecordId__c) + removedRecords);
-                                } else {
-                                    resolvedRecordsTracker.put(item.OwnerRecordId__c, removedRecords);
-                                }
-                            }
+
                             
                             System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (map) before=' + beforeCount + ' after=' + afterCount + ' removed=' + removedRecords);
                             // Avoid processing the same item again via string path which can cause duplicate DML IDs
@@ -759,15 +793,7 @@
                     }
                 }
                 
-                // Track the actual number of records resolved for this owner (string path)
-                if (removedRecordsStr > 0) {
-                    if (resolvedRecordsTracker.containsKey(item.OwnerRecordId__c)) {
-                        resolvedRecordsTracker.put(item.OwnerRecordId__c, 
-                            resolvedRecordsTracker.get(item.OwnerRecordId__c) + removedRecordsStr);
-                    } else {
-                        resolvedRecordsTracker.put(item.OwnerRecordId__c, removedRecordsStr);
-                    }
-                }
+
                 
                 System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (string) before=' + beforeCountStr + ' after=' + afterCountStr + ' removed=' + removedRecordsStr);
             }

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -325,9 +325,14 @@
 
         // Remove updated fields from payloads only if record had no errors
         Map<Id, List<String>> cleanUpdatedMap = new Map<Id, List<String>>();
+        System.debug('🔧 START: updatedFieldsPerRecord size: ' + updatedFieldsPerRecord.size());
+        System.debug('🔧 START: result.fieldErrors size: ' + result.fieldErrors.size());
+        
         for (String recordId : updatedFieldsPerRecord.keySet()) {
+            System.debug('🔧 Checking record: ' + recordId + ', has errors: ' + result.fieldErrors.containsKey(recordId));
             if (!result.fieldErrors.containsKey(recordId)) {
                 cleanUpdatedMap.put((Id) recordId, updatedFieldsPerRecord.get(recordId));
+                System.debug('🔧 Added to clean map: ' + recordId);
             }
         }
 

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -337,6 +337,7 @@
 
         if (!cleanUpdatedMap.isEmpty()) {
             Set<String> objectNames = new Set<String>(objectTypePerRecord.values());
+            System.debug('🔧 DEBUG: objectTypePerRecord map: ' + objectTypePerRecord);
             System.debug('🔧 Processing objects: ' + objectNames);
             System.debug('🔧 Clean updated map contains: ' + cleanUpdatedMap.keySet());
             

--- a/DynamicAgent.cls
+++ b/DynamicAgent.cls
@@ -486,6 +486,8 @@
         Map<Id, List<String>> updatedFieldsByRecordId, 
         Map<Id, Id> recordToOwnerMap
     ) {
+        System.debug('🚀 METHOD ENTRY: getRecordsResolvedAfterUpdate');
+        
         Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
         
         System.debug('🚀 getRecordsResolvedAfterUpdate STARTED');

--- a/WithoutAgentForceCntr.cls
+++ b/WithoutAgentForceCntr.cls
@@ -1,0 +1,698 @@
+/**
+ * @class DynamicAgent
+ * @author Ayushi patel
+ * @created 2025-07-15
+ * @description
+ * - Construct class to fetch the details of objects dynamically to the agent
+ * - Handle save the suggestions which is provide by agent
+ */
+public without sharing class WithoutAgentForceCntr {
+ @AuraEnabled
+ /**@description Saves field suggestions for one or more records received from the AI agent on the UI.
+    *This method supports both single-record and bulk updates, depending on the input
+    *@param recordFieldValues
+    *@return SaveResultWrapper
+    */
+public static SaveResultWrapper saveMultipleRecordFields(Map<String, Map<String, Object>> recordFieldValues) {
+        SaveResultWrapper result = new SaveResultWrapper();
+        result.fieldErrors = new Map<String, Map<String, String>>();
+        result.hasErrors = false;
+
+        if (recordFieldValues == null || recordFieldValues.isEmpty()) {
+            throw new AuraHandledException('No records provided for update.');
+        }
+
+        Map<String, SObject> recordsToUpdate = new Map<String, SObject>();
+        Map<String, List<String>> updatedFieldsPerRecord = new Map<String, List<String>>();
+        Map<String, String> objectTypePerRecord = new Map<String, String>();
+        // Group field errors by recordId
+        for (String recordId : recordFieldValues.keySet()) {
+            Map<String, Object> fields = recordFieldValues.get(recordId);
+            if (String.isBlank(recordId) || fields == null || fields.isEmpty()){
+                continue;
+            }
+
+            Id recordIdObj = (Id) recordId;
+            String objectApiName = recordIdObj.getSObjectType().getDescribe().getName();
+            objectTypePerRecord.put(recordId, objectApiName);
+            SObject record = (SObject) Type.forName('Schema.' + objectApiName).newInstance();
+            record.put('Id', recordId);
+
+            Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe().get(objectApiName).getDescribe().fields.getMap();
+            List<String> updatedFields = new List<String>();
+            Map<String, String> fieldErrors = new Map<String, String>();
+
+            for (String fieldApi : fields.keySet()) {
+                try {
+                    if (!fieldMap.containsKey(fieldApi)){
+                        continue;
+                    }
+
+                    Object value = fields.get(fieldApi);
+                    if (value == null || String.valueOf(value).trim() == ''){
+                        continue;
+                    }
+                    Schema.DisplayType fieldType = fieldMap.get(fieldApi).getDescribe().getType();
+                    Object convertedValue = convertValueByType(value, fieldType);
+
+                    if ((fieldType == Schema.DisplayType.String || fieldType == Schema.DisplayType.TextArea) && convertedValue != null) {
+                        Integer maxLength = fieldMap.get(fieldApi).getDescribe().getLength();
+                        if (String.valueOf(convertedValue).length() > maxLength) {
+                            fieldErrors.put(fieldApi, 'Too long (max ' + maxLength + ' characters)');
+                            continue;
+                        }
+                    }
+
+                  if ((fieldType == Schema.DisplayType.Currency || fieldType == Schema.DisplayType.Double) && convertedValue != null) {
+                    String strVal = String.valueOf(convertedValue).trim();
+
+                    if (!Pattern.matches('^-?\\d*(\\.\\d+)?$', strVal)) {
+                        fieldErrors.put(fieldApi, 'Enter Valid Number');
+                        continue;
+                    }
+
+                    Schema.DescribeFieldResult d = fieldMap.get(fieldApi).getDescribe();
+
+                    try {
+
+
+                    Integer digitsBefore = strVal.contains('.') ? strVal.split('\\.')[0].replace('-', '').length() : strVal.replace('-', '').length();
+                    Integer digitsAfter = strVal.contains('.') ? strVal.split('\\.')[1].length() : 0;
+
+                    if (digitsBefore + digitsAfter > d.getPrecision()) {
+                        fieldErrors.put(fieldApi, 'Value exceeds allowed precision: maximum ' + d.getPrecision() + ' digits allowed including decimals');
+
+                        continue;
+                    }
+                } catch (Exception e) {
+                    fieldErrors.put(fieldApi, 'Invalid number format.');
+                    continue;
+                }
+
+                }
+
+
+
+                    if (fieldType == Schema.DisplayType.Email && convertedValue != null) {
+                        if (!Pattern.matches('^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$', String.valueOf(convertedValue))) {
+                            fieldErrors.put(fieldApi, 'Invalid email format.');
+                            continue;
+                        }
+                    }
+
+                    if (fieldType == Schema.DisplayType.Phone && convertedValue != null) {
+                        String phoneDigits = String.valueOf(convertedValue).replaceAll('[^\\d]', '');
+                        if (phoneDigits.length() > 10) {
+                            fieldErrors.put(fieldApi, 'Phone number must be exactly 10 digits');
+                            continue;
+                        }
+                        if (!Pattern.matches('^[\\d\\-\\+()\\s]+$', String.valueOf(convertedValue))) {
+                            fieldErrors.put(fieldApi, 'Invalid phone number format.');
+                            continue;
+                        }
+                    }
+
+            if (fieldType == Schema.DisplayType.Percent && convertedValue != null) {
+                Decimal percentValue;
+                try {
+                    percentValue = Decimal.valueOf(String.valueOf(convertedValue));
+                } catch (Exception e) {
+                    fieldErrors.put(fieldApi, 'Invalid percent value.');
+                    continue;
+                }
+                if (percentValue < 0 || percentValue > 100) {
+                    fieldErrors.put(fieldApi, 'Percent must be between 0 and 100');
+                    continue;
+                }
+            }
+ if (fieldApi != null &&
+                    (fieldApi.toLowerCase().contains('website') || fieldType == Schema.DisplayType.Url)) {
+
+                    String urlStr = convertedValue == null ? '' : String.valueOf(convertedValue).trim();
+
+                    // Get max length dynamically from Salesforce schema
+                    Schema.DescribeSObjectResult objDescribe = Schema.getGlobalDescribe()
+                        .get(objectApiName)
+                        .getDescribe();
+                    Integer maxUrlLength = objDescribe.fields.getMap()
+                        .get(fieldApi)
+                        .getDescribe()
+                        .getLength();
+
+                    // Check blank or too long
+                    if (String.isBlank(urlStr) || urlStr.length() > maxUrlLength) {
+                        fieldErrors.put(fieldApi, 'URL is too long . Max length: ' + maxUrlLength);
+                        continue;
+                    }
+
+                    // Allow multi-subdomain URLs like Salesforce Lightning domains
+                    String regex = '^(https?://)?([\\w.-]+\\.)+[a-zA-Z]{2,}(:[0-9]+)?(/.*)?$';
+                    if (!Pattern.matches(regex, urlStr)) {
+                        fieldErrors.put(fieldApi, 'Invalid URL format.');
+                        continue;
+                    }
+                }
+
+                    record.put(fieldApi, convertedValue);
+                    updatedFields.add(fieldApi);
+
+                } catch (Exception e) {
+                    fieldErrors.put(fieldApi, 'Invalid value: ' + e.getMessage());
+                }
+            }
+
+            if (!fieldErrors.isEmpty()) {
+                result.fieldErrors.put(recordId, fieldErrors);
+            }
+
+            if (!updatedFields.isEmpty()) {
+                recordsToUpdate.put(recordId, record);
+                updatedFieldsPerRecord.put(recordId, updatedFields);
+            }
+        }
+
+        // Bulk DML with error mapping
+        if (!recordsToUpdate.isEmpty()) {
+    try {
+        update recordsToUpdate.values();
+}catch (DmlException dmlEx) {
+    for (Integer i = 0; i < dmlEx.getNumDml(); i++) {
+        String msg = dmlEx.getDmlMessage(i);
+        Id dmlRecordId = (Id) dmlEx.getDmlId(i);
+        String recId = String.valueOf(dmlRecordId);
+        String fieldMatch = 'Unknown';
+        String fieldType = 'UNKNOWN';
+        String finalMsg = msg;
+
+        // Try to extract [FieldName]
+        Matcher m = Pattern.compile('\\[([a-zA-Z0-9_]+)\\]').matcher(msg);
+        if (m.find()) {
+            fieldMatch = m.group(1);
+        }
+
+        // Handle duplicate value errors explicitly
+        if (msg != null && msg.containsIgnoreCase('duplicate value')) {
+            List<String> fields = new List<String>();
+            for (String part : msg.split(',')) {
+                part = part.trim();
+                Integer idx = part.indexOf(' duplicates value');
+                if (idx > 0) {
+                    String apiName = part.substring(0, idx).trim();
+                    String label = apiName.replaceAll('__c', '').replaceAll('_', ' ').trim();
+                    fields.add(label);
+                }
+            }
+
+            finalMsg = fields.isEmpty()
+                ? 'Duplicate value error. Some fields must be unique.'
+                : 'This value already exist';
+
+            fieldMatch = 'Unknown'; // To trigger top-level error
+        } else if (fieldMatch != 'Unknown') {
+            // Only try to get field type when field name is known
+            if (objectTypePerRecord.containsKey(recId)) {
+                Map<String, Schema.SObjectField> fMap = Schema.getGlobalDescribe()
+                    .get(objectTypePerRecord.get(recId)).getDescribe().fields.getMap();
+                if (fMap.containsKey(fieldMatch)) {
+                    fieldType = fMap.get(fieldMatch).getDescribe().getType().name();
+                }
+            }
+        }
+
+        // Never try to infer field by value in this catch block.
+        // If no match, assign to 'Unknown'
+
+        // Populate error map
+        if (!result.fieldErrors.containsKey(recId)) {
+            result.fieldErrors.put(recId, new Map<String, String>());
+        }
+        result.fieldErrors.get(recId).put(fieldMatch, finalMsg);
+    }
+}
+
+}
+
+if (!result.fieldErrors.isEmpty()) {
+    throw new AuraHandledException(JSON.serialize(result.fieldErrors));
+}
+
+        // Remove updated fields from payloads only if record had no errors
+        Map<Id, List<String>> cleanUpdatedMap = new Map<Id, List<String>>();
+        for (String recordId : updatedFieldsPerRecord.keySet()) {
+            if (!result.fieldErrors.containsKey(recordId)) {
+                cleanUpdatedMap.put((Id) recordId, updatedFieldsPerRecord.get(recordId));
+            }
+        }
+
+         if (!cleanUpdatedMap.isEmpty()) {
+        // Step 1: Collect all object names
+        Set<String> objectNames = new Set<String>(objectTypePerRecord.values());
+
+        // Step 2: Bulk query to get latest Object_Tracker__c per object name
+        Map<String, Object_Tracker__c> latestTrackersByName = new Map<String, Object_Tracker__c>();
+        for (Object_Tracker__c tracker : [
+            SELECT Id, Name
+            FROM Object_Tracker__c
+            WHERE Name IN :objectNames
+            WITH SECURITY_ENFORCED
+            ORDER BY CreatedDate DESC
+        ]) {
+            String nameKey = tracker.Name.toLowerCase();
+            if (!latestTrackersByName.containsKey(nameKey)) {
+                latestTrackersByName.put(nameKey, tracker);
+            }
+        }
+
+        // Step 3: Use map instead of querying inside loop
+        for (String obj : objectNames) {
+            String objKey = obj.toLowerCase();
+            if (latestTrackersByName.containsKey(objKey)) {
+                // Filter records for this specific object type
+                Map<Id, List<String>> objectSpecificUpdates = new Map<Id, List<String>>();
+                for (Id recordId : cleanUpdatedMap.keySet()) {
+                    String recordObjectType = recordId.getSObjectType().getDescribe().getName();
+                    if (recordObjectType == obj) {
+                        objectSpecificUpdates.put(recordId, cleanUpdatedMap.get(recordId));
+                    }
+                }
+                
+                if (!objectSpecificUpdates.isEmpty()) {
+                    Id trackerId = latestTrackersByName.get(objKey).Id;
+                    removeUpdatedFieldsFromPayloadBatch(trackerId, objectSpecificUpdates);
+                    // Update user validation counts after successful updates
+                    updateUserValidationCounts(trackerId, objectSpecificUpdates);
+                }
+            }
+        }
+    }
+
+        result.hasErrors = !result.fieldErrors.isEmpty();
+        return result;
+    }
+
+    /**
+     * @description Update user validation counts in Object_Tracker__c.User_Record_Summary__c
+     * after successful record updates. Counts records that were completely removed from payload.
+     * @param trackerId The Object_Tracker__c record ID
+     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
+     */
+    public static void updateUserValidationCounts(Id trackerId, Map<Id, List<String>> updatedFieldsByRecordId) {
+        if (trackerId == null || updatedFieldsByRecordId == null || updatedFieldsByRecordId.isEmpty()) {
+            return;
+        }
+
+        try {
+            // Get the Object_Tracker__c record with current User_Record_Summary__c
+            List<Object_Tracker__c> trackers = [
+                SELECT Id, Name, User_Record_Summary__c 
+                FROM Object_Tracker__c 
+                WHERE Id = :trackerId 
+                WITH SECURITY_ENFORCED
+                LIMIT 1
+            ];
+
+            if (trackers.isEmpty() || String.isBlank(trackers[0].User_Record_Summary__c)) {
+                return;
+            }
+
+            Object_Tracker__c tracker = trackers[0];
+            
+            // Parse the current user validation JSON
+            Map<String, Object> userValidationMap;
+            try {
+                userValidationMap = (Map<String, Object>) JSON.deserializeUntyped(tracker.User_Record_Summary__c);
+            } catch (Exception e) {
+                System.debug('Error parsing User_Record_Summary__c JSON: ' + e.getMessage());
+                return;
+            }
+
+            // Get owner information for the updated records
+            Set<Id> recordIds = updatedFieldsByRecordId.keySet();
+            Map<Id, Id> recordToOwnerMap = getRecordOwners(recordIds);
+
+            // Count records that were completely resolved (removed from payload) per user
+            Map<Id, Integer> userToResolvedRecordsCount = getResolvedRecordsCount(trackerId, updatedFieldsByRecordId, recordToOwnerMap);
+
+            // Update the user validation counts
+            Boolean hasChanges = false;
+            for (Id userId : userToResolvedRecordsCount.keySet()) {
+                String userIdStr = String.valueOf(userId);
+                if (userValidationMap.containsKey(userIdStr)) {
+                    String currentValue = String.valueOf(userValidationMap.get(userIdStr));
+                    if (currentValue.contains('/')) {
+                        String[] parts = currentValue.split('/');
+                        if (parts.size() == 2) {
+                            try {
+                                Integer currentMissing = Integer.valueOf(parts[0]);
+                                Integer totalRecords = Integer.valueOf(parts[1]);
+                                Integer resolvedRecords = userToResolvedRecordsCount.get(userId);
+                                
+                                // Decrease missing count by the number of records that were completely resolved
+                                Integer newMissing = Math.max(0, currentMissing - resolvedRecords);
+                                
+                                String newValue = newMissing + '/' + totalRecords;
+                                userValidationMap.put(userIdStr, newValue);
+                                hasChanges = true;
+
+                            } catch (Exception e) {
+                                System.debug('Error updating count for user ' + userIdStr + ': ' + e.getMessage());
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Update the Object_Tracker__c record if there were changes
+            if (hasChanges) {
+                tracker.User_Record_Summary__c = JSON.serialize(userValidationMap);
+                if (Schema.sObjectType.Object_Tracker__c.isUpdateable()) {
+                    update tracker;
+                } else {
+                    throw new AuraHandledException('You do not have permission to update Object_Tracker__c records.');
+                }
+            }
+
+        } catch (Exception e) {
+            System.debug('Error in updateUserValidationCounts: ' + e.getMessage());
+            // Don't throw exception to avoid breaking the main flow
+        }
+    }
+
+    /**
+     * @description Count how many records were completely resolved (removed from payload) per user
+     * @param trackerId The Object_Tracker__c record ID
+     * @param updatedFieldsByRecordId Map of record IDs to list of updated fields
+     * @param recordToOwnerMap Map of record ID to owner ID
+     * @return Map of user ID to count of completely resolved records
+     */
+    private static Map<Id, Integer> getResolvedRecordsCount(
+        Id trackerId, 
+        Map<Id, List<String>> updatedFieldsByRecordId, 
+        Map<Id, Id> recordToOwnerMap
+    ) {
+        Map<Id, Integer> userToResolvedRecordsCount = new Map<Id, Integer>();
+        
+        try {
+            // Get owner IDs for the updated records
+            Set<Id> ownerIds = new Set<Id>(recordToOwnerMap.values());
+            
+            // Query Owner_based_Line_Items__c to check current payload state after updates
+            List<Owner_based_Line_Items__c> items = [
+                SELECT Id, OwnerRecordId__c, Payload__c
+                FROM Owner_based_Line_Items__c
+                WHERE OwnerRecordId__c IN :ownerIds
+                AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
+                WITH SECURITY_ENFORCED
+            ];
+
+            // For each owner, check which updated records are no longer in their payload
+            for (Owner_based_Line_Items__c item : items) {
+                Id ownerId = item.OwnerRecordId__c;
+                Integer resolvedCount = 0;
+
+                // Check each record that was updated for this owner
+                for (Id recordId : updatedFieldsByRecordId.keySet()) {
+                    if (recordToOwnerMap.get(recordId) == ownerId) {
+                        // Check if this record is no longer in the payload (completely resolved)
+                        String recordIdStr = String.valueOf(recordId);
+                        Boolean recordStillInPayload = false;
+                        
+                        if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
+                            recordStillInPayload = item.Payload__c.contains('"' + recordIdStr + '":');
+                        }
+                        
+                        if (!recordStillInPayload) {
+                            // Record was completely removed from payload (all missing fields resolved)
+                            resolvedCount++;
+                        }
+                    }
+                }
+
+                if (resolvedCount > 0) {
+                    userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                }
+            }
+
+        } catch (Exception e) {
+            System.debug('Error in getResolvedRecordsCount: ' + e.getMessage());
+        }
+
+        return userToResolvedRecordsCount;
+    }
+
+    /**
+     * @description Get owner IDs for a set of record IDs
+     * @param recordIds Set of record IDs
+     * @return Map of record ID to owner ID
+     */
+    private static Map<Id, Id> getRecordOwners(Set<Id> recordIds) {
+        Map<Id, Id> recordToOwnerMap = new Map<Id, Id>();
+        
+        if (recordIds.isEmpty()) {
+            return recordToOwnerMap;
+        }
+
+        // Group records by object type for efficient querying
+        Map<String, Set<Id>> objectTypeToRecordIds = new Map<String, Set<Id>>();
+        for (Id recordId : recordIds) {
+            String objectType = recordId.getSObjectType().getDescribe().getName();
+            if (!objectTypeToRecordIds.containsKey(objectType)) {
+                objectTypeToRecordIds.put(objectType, new Set<Id>());
+            }
+            objectTypeToRecordIds.get(objectType).add(recordId);
+        }
+
+        // Query each object type separately
+        for (String objectType : objectTypeToRecordIds.keySet()) {
+            try {
+                Set<Id> ids = objectTypeToRecordIds.get(objectType);
+                String soql = 'SELECT Id, OwnerId FROM ' + String.escapeSingleQuotes(objectType) + ' WHERE Id IN :ids WITH SECURITY_ENFORCED';
+                List<SObject> records = Database.query(soql);
+                
+                for (SObject record : records) {
+                    recordToOwnerMap.put((Id)record.get('Id'), (Id)record.get('OwnerId'));
+                }
+            } catch (Exception e) {
+                System.debug('Error querying owners for object type ' + objectType + ': ' + e.getMessage());
+            }
+        }
+
+        return recordToOwnerMap;
+    }
+
+    /**@description Batch update: Remove updated fields from Owner_based_Line_Items__c.Payload__c for all updated records/fields.
+     * Called after successful record update(s) from UI.
+     */
+   public static void removeUpdatedFieldsFromPayloadBatch(
+        Id trackerId,
+        Map<Id, List<String>> updatedFieldsByRecordId
+    ) {
+        if (trackerId == null || updatedFieldsByRecordId == null || updatedFieldsByRecordId.isEmpty()){
+            return;
+        }
+        // Group recordIds by ownerId for efficient SOQL
+        Set<Id> recordIds = new Set<Id>(updatedFieldsByRecordId.keySet());
+        // Group recordIds by object type
+        Map<String, Set<Id>> objectTypeToRecordIds = new Map<String, Set<Id>>();
+        for (Id recId : recordIds) {
+            String objApi = recId.getSObjectType().getDescribe().getName();
+            if (!objectTypeToRecordIds.containsKey(objApi)){
+                objectTypeToRecordIds.put(objApi, new Set<Id>());
+            }
+            objectTypeToRecordIds.get(objApi).add(recId);
+        }
+
+        Map<Id, SObject> recs = new Map<Id, SObject>();
+
+            if (!objectTypeToRecordIds.isEmpty()) {
+                String objApi = objectTypeToRecordIds.keySet().iterator().next(); // Get the only object type
+                Set<Id> ids = objectTypeToRecordIds.get(objApi);
+
+                if (!ids.isEmpty()) {
+                    String soql = String.escapeSingleQuotes('SELECT Id, OwnerId FROM ' + objApi + ' WHERE Id IN :ids');
+                    recs.putAll(new Map<Id, SObject>(Database.query(soql)));
+                }
+            }
+
+        // Map ownerId to recordIds
+        Map<Id, List<Id>> ownerToRecordIds = new Map<Id, List<Id>>();
+        for (Id recId : recs.keySet()) {
+            Id ownerId = (Id) recs.get(recId).get('OwnerId');
+            if (!ownerToRecordIds.containsKey(ownerId)){
+                ownerToRecordIds.put(ownerId, new List<Id>());
+            }
+            ownerToRecordIds.get(ownerId).add(recId);
+        }
+        // Query all Owner_based_Line_Items__c for these owners/tracker
+        List<Owner_based_Line_Items__c> items = [
+            SELECT Id, OwnerRecordId__c, Payload__c
+            FROM Owner_based_Line_Items__c
+            WHERE OwnerRecordId__c IN :ownerToRecordIds.keySet()
+            AND Object_Line_Tracker__r.Object_Tracker__c = :trackerId
+            WITH SECURITY_ENFORCED
+
+        ];
+        List<Owner_based_Line_Items__c> toUpdate = new List<Owner_based_Line_Items__c>();
+        for (Owner_based_Line_Items__c item : items) {
+            if (String.isBlank(item.Payload__c)){
+                continue;
+            }
+            Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(item.Payload__c);
+            Boolean changed = false;
+            for (Id recId : ownerToRecordIds.get(item.OwnerRecordId__c)) {
+                if (payload.containsKey((String)recId)) {
+                    List<Object> missingFieldsObj = (List<Object>) payload.get((String)recId);
+                    // Convert to List<String> for easier removal
+                    List<String> missingFields = new List<String>();
+                    for (Object o : missingFieldsObj) {
+                        missingFields.add(String.valueOf(o));
+                    }
+                    for (String field : updatedFieldsByRecordId.get(recId)) {
+                        // Remove all occurrences of the field
+                        for (Integer i = missingFields.size() - 1; i >= 0; i--) {
+                            if (missingFields[i] == field) {
+                                missingFields.remove(i);
+                            }
+                        }
+                    }
+                    if (missingFields.isEmpty()) {
+                        payload.remove((String)recId);
+                    } else {
+                        // Convert back to List<Object> for serialization
+                        List<Object> newMissingFieldsObj = new List<Object>();
+                        for (String s : missingFields) {
+                            newMissingFieldsObj.add(s);
+                        }
+                        payload.put((String)recId, newMissingFieldsObj);
+                    }
+                    changed = true;
+                }
+            }
+            if (changed) {
+                item.Payload__c = payload.isEmpty() ? null : JSON.serialize(payload);
+                toUpdate.add(item);
+            }
+        }
+       if (!toUpdate.isEmpty()) {
+    // Check if the user has update access to this object
+            if (Schema.sObjectType.Owner_based_Line_Items__c.isUpdateable()) {
+                update toUpdate;
+            } else {
+                throw New AuraHandledException('You do not have permission to update records of type Owner_based_Line_Items__c.');
+            }
+        }
+    }
+
+    /**@description convertValueByType method to check dataType
+     * @param value: value to be converted
+     * @param fieldType: dataType of the value
+     * @return Object: converted value
+     */
+
+   public static Object convertValueByType(Object value, Schema.DisplayType fieldType) {
+    if (value == null) {
+        return null;
+    }
+
+    try {
+        switch on fieldType {
+            when CURRENCY, DOUBLE, PERCENT {
+                if (value instanceof String) {
+                    String clean = ((String)value).replace(',', '');
+                    return String.isBlank(clean) ? null : Decimal.valueOf(clean);
+                }
+                return value;
+            }
+            when INTEGER {
+                if (value instanceof String) {
+                    String clean = ((String)value).replace(',', '');
+                    return String.isBlank(clean) ? null : Integer.valueOf(clean);
+                }
+                return value;
+            }
+            when LONG {
+                if (value instanceof String) {
+                    String clean = ((String)value).replace(',', '');
+                    return String.isBlank(clean) ? null : Long.valueOf(clean);
+                }
+                return value;
+            }
+            when BOOLEAN {
+                if (value instanceof String) {
+                    return Boolean.valueOf((String)value);
+                }
+                return value;
+            }
+            when DATE {
+                if (value instanceof String) {
+                    return String.isBlank((String)value) ? null : Date.valueOf((String)value);
+                }
+                return value;
+            }
+         when DATETIME {
+    if (value instanceof String) {
+        String dtStr = (String) value;
+        if (String.isBlank(dtStr)) {
+            return null;
+        }
+
+        if (dtStr.contains('T')) {
+            String[] parts = dtStr.split('T');
+            if (parts.size() == 2) {
+                String datePart = parts[0];
+                String timePart = parts[1];
+                Boolean isUTC = false;
+
+                // Detect UTC indicator 'Z'
+                if (timePart.endsWith('Z')) {
+                    timePart = timePart.substring(0, timePart.length() - 1);
+                    isUTC = true;
+                }
+
+                // Remove milliseconds if present
+                if (timePart.contains('.')) {
+                    timePart = timePart.split('\\.')[0];
+                }
+
+                DateTime parsed = DateTime.valueOf(datePart + ' ' + timePart);
+
+                // Convert from UTC to user's timezone if 'Z' was present
+                if (isUTC) {
+                    Integer offsetSeconds = Math.mod(UserInfo.getTimeZone().getOffset(parsed), 86400000) / 1000;
+                    parsed = parsed.addSeconds(offsetSeconds);
+                }
+
+                return parsed;
+            }
+        }
+
+        // Fallback if it's already in a valid DateTime format
+        return DateTime.valueOf(dtStr);
+    }
+    return value;
+}
+
+           when TIME {
+                if (value instanceof String) {
+                    String[] parts = ((String)value).split(':');
+                    if (parts.size() == 3) {
+                        return Time.newInstance(Integer.valueOf(parts[0]), Integer.valueOf(parts[1]), Integer.valueOf(parts[2]), 0);
+                    }
+                }
+                return value;
+            }
+            when else {
+                return value;
+            }
+        }
+    } catch (Exception e) {
+        return value;
+    }
+}
+    /**@description SaveResultWrapper
+     */
+        public class SaveResultWrapper {
+            @AuraEnabled public Boolean hasErrors;
+            @AuraEnabled public Map<String, Map<String, String>> fieldErrors;
+    }
+}

--- a/WithoutAgentForceCntr.cls
+++ b/WithoutAgentForceCntr.cls
@@ -405,31 +405,51 @@ if (!result.fieldErrors.isEmpty()) {
                 WITH SECURITY_ENFORCED
             ];
 
-            // For each owner, check which updated records are no longer in their payload
+            // Group all payloads by owner to avoid double counting
+            Map<Id, List<Owner_based_Line_Items__c>> ownerToPayloads = new Map<Id, List<Owner_based_Line_Items__c>>();
             for (Owner_based_Line_Items__c item : items) {
                 Id ownerId = item.OwnerRecordId__c;
+                if (!ownerToPayloads.containsKey(ownerId)) {
+                    ownerToPayloads.put(ownerId, new List<Owner_based_Line_Items__c>());
+                }
+                ownerToPayloads.get(ownerId).add(item);
+            }
+
+            // Process each owner only once, checking all their payloads
+            for (Id ownerId : ownerToPayloads.keySet()) {
+                List<Owner_based_Line_Items__c> ownerPayloads = ownerToPayloads.get(ownerId);
                 Integer resolvedCount = 0;
 
                 // Check each record that was updated for this owner
                 for (Id recordId : updatedFieldsByRecordId.keySet()) {
                     if (recordToOwnerMap.get(recordId) == ownerId) {
-                        // Check if this record is no longer in the payload (completely resolved)
                         String recordIdStr = String.valueOf(recordId);
-                        Boolean recordStillInPayload = false;
                         
-                        if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
-                            recordStillInPayload = item.Payload__c.contains('"' + recordIdStr + '":');
+                        // Check if this record is still in ANY of the owner's payloads
+                        Boolean recordStillInAnyPayload = false;
+                        
+                        for (Owner_based_Line_Items__c item : ownerPayloads) {
+                            if (String.isNotBlank(item.Payload__c) && item.Payload__c != '{}' && item.Payload__c != '[]') {
+                                if (item.Payload__c.contains('"' + recordIdStr + '":')) {
+                                    recordStillInAnyPayload = true;
+                                    break; // Found in one payload, no need to check others
+                                }
+                            }
                         }
                         
-                        if (!recordStillInPayload) {
-                            // Record was completely removed from payload (all missing fields resolved)
+                        if (!recordStillInAnyPayload) {
+                            // Record was completely removed from ALL payloads (all missing fields resolved)
                             resolvedCount++;
+                            System.debug('✅ Record ' + recordIdStr + ' completely resolved for owner ' + ownerId);
+                        } else {
+                            System.debug('⚠️ Record ' + recordIdStr + ' still has missing fields for owner ' + ownerId);
                         }
                     }
                 }
 
                 if (resolvedCount > 0) {
                     userToResolvedRecordsCount.put(ownerId, resolvedCount);
+                    System.debug('🎯 Owner ' + ownerId + ' had ' + resolvedCount + ' records completely resolved - COUNT WILL DECREASE BY ' + resolvedCount);
                 }
             }
 

--- a/WithoutAgentForceCntr.cls
+++ b/WithoutAgentForceCntr.cls
@@ -533,44 +533,195 @@ if (!result.fieldErrors.isEmpty()) {
 
         ];
         List<Owner_based_Line_Items__c> toUpdate = new List<Owner_based_Line_Items__c>();
+
+        // Process each item once to avoid multiple deserializations
         for (Owner_based_Line_Items__c item : items) {
             if (String.isBlank(item.Payload__c)){
                 continue;
             }
-            Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(item.Payload__c);
+
+            // Check payload size - use string operations for large payloads instead of skipping
+            Boolean isLargePayload = item.Payload__c.length() > 25000;
+            if (isLargePayload) {
+                System.debug('Processing large payload with string operations: ' + item.Id + ' size: ' + item.Payload__c.length());
+            }
+
+            // Process payload; prefer small-payload Map-based path, fall back to string ops for larger payloads
+            String payloadStr = item.Payload__c;
             Boolean changed = false;
-            for (Id recId : ownerToRecordIds.get(item.OwnerRecordId__c)) {
-                if (payload.containsKey((String)recId)) {
-                    List<Object> missingFieldsObj = (List<Object>) payload.get((String)recId);
-                    // Convert to List<String> for easier removal
-                    List<String> missingFields = new List<String>();
-                    for (Object o : missingFieldsObj) {
-                        missingFields.add(String.valueOf(o));
+
+            try {
+                // Try Map-based approach first for small payloads only
+                if (!isLargePayload && item.Payload__c.length() <= 12000) {
+                    try {
+                        Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(payloadStr);
+                        if (payload != null) {
+                            Integer beforeCount = payload.size();
+                            List<Id> recList = ownerToRecordIds.containsKey(item.OwnerRecordId__c) ? ownerToRecordIds.get(item.OwnerRecordId__c) : new List<Id>();
+                            for (Id recId : recList) {
+                                String recKey = (String)recId;
+                                if (payload.containsKey(recKey)) {
+                                    List<Object> missingFieldsObj = (List<Object>) payload.get(recKey);
+                                    List<String> missingFields = new List<String>();
+                                    if (missingFieldsObj != null) {
+                                        for (Object o : missingFieldsObj) {
+                                            missingFields.add(String.valueOf(o));
+                                        }
+                                    }
+                                    List<String> upd = updatedFieldsByRecordId.get(recId);
+                                    if (upd != null) {
+                                        for (String field : upd) {
+                                            for (Integer i = missingFields.size() - 1; i >= 0; i--) {
+                                                if (missingFields[i] == field) {
+                                                    missingFields.remove(i);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if (missingFields.isEmpty()) {
+                                        payload.remove(recKey);
+                                    } else {
+                                        List<Object> newMissingFieldsObj = new List<Object>();
+                                        for (String s : missingFields) {
+                                            newMissingFieldsObj.add(s);
+                                        }
+                                        payload.put(recKey, newMissingFieldsObj);
+                                    }
+                                    changed = true;
+                                }
+                            }
+                            if (changed) {
+                                Integer afterCount = payload.size();
+                                Integer removedRecords = beforeCount - afterCount;
+                                item.Payload__c = payload.isEmpty() ? null : JSON.serialize(payload);
+                                payloadStr = item.Payload__c == null ? '{}' : item.Payload__c;
+                                toUpdate.add(item);
+                                
+                                System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (map) before=' + beforeCount + ' after=' + afterCount + ' removed=' + removedRecords);
+                                // Avoid processing the same item again via string path which can cause duplicate DML IDs
+                                continue;
+                            }
+                        }
+                    } catch (Exception ex) {
+                        changed = false; // fallback to string path below
                     }
-                    for (String field : updatedFieldsByRecordId.get(recId)) {
-                        // Remove all occurrences of the field
-                        for (Integer i = missingFields.size() - 1; i >= 0; i--) {
-                            if (missingFields[i] == field) {
-                                missingFields.remove(i);
+                }
+
+                // String-based processing for large payloads
+                List<Id> ownerRecIds = ownerToRecordIds.containsKey(item.OwnerRecordId__c) ? ownerToRecordIds.get(item.OwnerRecordId__c) : new List<Id>();
+                Integer removedRecordsStr = 0;
+                Integer beforeCountStr = 0;
+                if (String.isNotBlank(payloadStr)) {
+                    Integer idxScan = 0;
+                    String marker = '\":[\"';
+                    while (true) {
+                        Integer pos = payloadStr.indexOf(marker, idxScan);
+                        if (pos == -1) break;
+                        beforeCountStr++;
+                        idxScan = pos + marker.length();
+                    }
+                }
+                for (Id recId : ownerRecIds) {
+                    if (changed) { break; }
+                    String recIdStr = (String)recId;
+                    if (payloadStr.contains('"' + recIdStr + '"')) {
+                        // Find the record entry in the JSON string using Apex methods
+                        String searchKey = '"' + recIdStr + '":';
+                        Integer startIndex = payloadStr.indexOf(searchKey);
+
+                        if (startIndex != -1) {
+                            // Find the opening bracket after the key
+                            Integer bracketStart = payloadStr.indexOf('[', startIndex);
+                            if (bracketStart != -1) {
+                                // Find the closing bracket
+                                Integer bracketEnd = payloadStr.indexOf(']', bracketStart);
+                                if (bracketEnd != -1) {
+                                    // Extract the fields string
+                                    String fieldsStr = payloadStr.substring(bracketStart + 1, bracketEnd);
+                                    List<String> missingFields = new List<String>();
+
+                                    // Parse fields from the string
+                                    if (String.isNotBlank(fieldsStr)) {
+                                        String[] fieldParts = fieldsStr.split(',');
+                                        for (String field : fieldParts) {
+                                            field = field.trim().replaceAll('"', '');
+                                            if (String.isNotBlank(field)) {
+                                                missingFields.add(field);
+                                            }
+                                        }
+                                    }
+
+                                    // Remove updated fields
+                                    for (String field : updatedFieldsByRecordId.get(recId)) {
+                                        // Remove all occurrences of the field
+                                        for (Integer i = missingFields.size() - 1; i >= 0; i--) {
+                                            if (missingFields[i] == field) {
+                                                missingFields.remove(i);
+                                            }
+                                        }
+                                    }
+
+                                    // Reconstruct the JSON string
+                                    if (missingFields.isEmpty()) {
+                                        // Remove entire record entry
+                                        String beforeRecord = payloadStr.substring(0, startIndex);
+                                        String afterRecord = payloadStr.substring(bracketEnd + 1);
+
+                                        // Remove trailing comma if present
+                                        if (beforeRecord.endsWith(',')) {
+                                            beforeRecord = beforeRecord.substring(0, beforeRecord.length() - 1);
+                                        }
+                                        if (afterRecord.startsWith(',')) {
+                                            afterRecord = afterRecord.substring(1);
+                                        }
+
+                                        payloadStr = beforeRecord + afterRecord;
+                                        removedRecordsStr++;
+                                    } else {
+                                        // Update the fields array
+                                        String newFieldsStr = '"' + String.join(missingFields, '","') + '"';
+                                        String beforeBracket = payloadStr.substring(0, bracketStart + 1);
+                                        String afterBracket = payloadStr.substring(bracketEnd);
+                                        payloadStr = beforeBracket + newFieldsStr + afterBracket;
+                                    }
+                                    changed = true;
+                                }
                             }
                         }
                     }
-                    if (missingFields.isEmpty()) {
-                        payload.remove((String)recId);
-                    } else {
-                        // Convert back to List<Object> for serialization
-                        List<Object> newMissingFieldsObj = new List<Object>();
-                        for (String s : missingFields) {
-                            newMissingFieldsObj.add(s);
-                        }
-                        payload.put((String)recId, newMissingFieldsObj);
-                    }
-                    changed = true;
                 }
-            }
-            if (changed) {
-                item.Payload__c = payload.isEmpty() ? null : JSON.serialize(payload);
-                toUpdate.add(item);
+
+                // Clean up the JSON string
+                if (changed) {
+                    // Remove trailing commas and clean up using Apex methods
+                    payloadStr = payloadStr.replace(',}', '}');
+                    payloadStr = payloadStr.replace(',]', ']');
+                    payloadStr = payloadStr.replace('{,}', '{}');
+
+                    if (payloadStr.trim() == '{}' || payloadStr.trim() == '' || payloadStr.trim() == '[]') {
+                        item.Payload__c = null;
+                    } else {
+                        item.Payload__c = payloadStr;
+                    }
+                    toUpdate.add(item);
+                    Integer afterCountStr = 0;
+                    if (String.isNotBlank(item.Payload__c)) {
+                        Integer idxScan2 = 0;
+                        String marker2 = '\":[\"';
+                        while (true) {
+                            Integer pos2 = item.Payload__c.indexOf(marker2, idxScan2);
+                            if (pos2 == -1) break;
+                            afterCountStr++;
+                            idxScan2 = pos2 + marker2.length();
+                        }
+                    }
+                    
+                    System.debug('Owner ' + String.valueOf(item.OwnerRecordId__c) + ' Item ' + item.Id + ' (string) before=' + beforeCountStr + ' after=' + afterCountStr + ' removed=' + removedRecordsStr);
+                }
+            } catch (Exception e) {
+                System.debug('Error processing payload for item ' + item.Id + ': ' + e.getMessage());
+                // Skip this item if there's an error
+                continue;
             }
         }
        if (!toUpdate.isEmpty()) {


### PR DESCRIPTION
Update `Object_Tracker__c.User_Record_Summary__c` to reflect accurate missing record counts after successful field updates.

The existing `saveMultipleRecordFields` method updated records and removed fields from `Owner_based_Line_Items__c.Payload__c`, but did not update the `User_Record_Summary__c` field on the `Object_Tracker__c` record. This PR introduces `updateUserValidationCounts` to parse the user summary JSON, decrement the 'missing' count for affected users based on successfully updated fields, and then save the updated JSON back to the `Object_Tracker__c` record.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1715c6f-e618-4371-a882-14faf55bb4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1715c6f-e618-4371-a882-14faf55bb4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

